### PR TITLE
Replaced topK with topKV2.

### DIFF
--- a/tensorflow-ops/src/TensorFlow/Ops.hs
+++ b/tensorflow-ops/src/TensorFlow/Ops.hs
@@ -95,7 +95,6 @@ module TensorFlow.Ops
     , CoreOps.sparseToDense
     , CoreOps.sub
     , CoreOps.sum
-    , CoreOps.topK
     , CoreOps.transpose
     , truncatedNormal
     , variable

--- a/tensorflow-ops/tensorflow-ops.cabal
+++ b/tensorflow-ops/tensorflow-ops.cabal
@@ -160,6 +160,7 @@ Test-Suite MiscTest
                , google-shim
                , transformers
                , tensorflow
+               , tensorflow-core-ops
                , tensorflow-ops
                , tensorflow-proto
                , test-framework

--- a/tensorflow-ops/tests/MiscTest.hs
+++ b/tensorflow-ops/tests/MiscTest.hs
@@ -23,6 +23,7 @@ import Test.Framework.Providers.HUnit (testCase)
 import Test.HUnit ((@=?))
 import Google.Test
 import qualified Data.Vector as V
+import qualified TensorFlow.GenOps.Core as CoreOps
 
 import TensorFlow.Ops
 import TensorFlow.Session
@@ -30,7 +31,8 @@ import TensorFlow.Session
 -- | Test fetching multiple outputs from an op.
 testMultipleOutputs = testCase "testMultipleOutputs" $
     runSession $ do
-        (values, indices) <- run $ topK 2 $ constant [1, 4] [10, 40, 20, 30]
+        (values, indices) <-
+            run $ CoreOps.topKV2 (constant [1, 4] [10, 40, 20, 30]) 2
         liftIO $ [40, 30] @=? V.toList (values :: V.Vector Float)
         liftIO $ [1, 3] @=? V.toList (indices :: V.Vector Int32)
 


### PR DESCRIPTION
topK is obsolete and generating warnings.