### PR TITLE
test case to show can't calculate grad for embedding (and associated fix)

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -11,6 +11,7 @@ packages:
 - tensorflow-mnist-input-data
 - tensorflow-queue
 - tensorflow-nn
+- tensorflow-test
 
 extra-deps:
 # proto-lens is not yet in Stackage.

--- a/tensorflow-nn/tensorflow-nn.cabal
+++ b/tensorflow-nn/tensorflow-nn.cabal
@@ -30,6 +30,7 @@ Test-Suite NNTest
                , QuickCheck
                , base
                , tensorflow
+               , tensorflow-test
                , tensorflow-ops
                , tensorflow-nn
                , google-shim

--- a/tensorflow-nn/tests/NNTest.hs
+++ b/tensorflow-nn/tests/NNTest.hs
@@ -22,6 +22,7 @@ module Main where
 
 import           Data.Maybe                         (fromMaybe)
 import           Google.Test                        (googleTest)
+import           TensorFlow.Test                    (assertAllClose)
 import           Test.Framework.Providers.HUnit     (testCase)
 import           Test.HUnit                         ((@?))
 import           Test.HUnit.Lang                    (Assertion(..))
@@ -61,15 +62,6 @@ defInputs = Inputs {
       logits    = [-100, -2, -2, 0, 2, 2,   2, 100]
     , targets   = [   0,  0,  1, 0, 0, 1, 0.5,   1]
     }
-
-
-assertAllClose :: V.Vector Float -> V.Vector Float -> Assertion
-assertAllClose xs ys = all (<= tol) (V.zipWith absDiff xs ys) @?
-    ("Difference > tolerance: \nxs: " ++ show xs ++ "\nys: " ++ show ys
-        ++ "\ntolerance: " ++ show tol)
-  where
-      absDiff x y = abs (x - y)
-      tol = 0.001 :: Float
 
 
 testLogisticOutput = testCase "testLogisticOutput" $ do

--- a/tensorflow-ops/src/TensorFlow/Gradient.hs
+++ b/tensorflow-ops/src/TensorFlow/Gradient.hs
@@ -407,13 +407,13 @@ toT = Tensor ValueKind
 -- | Wrapper around `TensorFlow.GenOps.Core.slice` that builds vectors from scalars for
 -- simple slicing operations.
 flatSlice :: forall v1 t i . (TensorType t)
-         => Tensor v1 t -- ^ __input__
-         -> Int32 -- ^ __begin__: specifies the offset into the first dimension of
-                            -- 'input' to slice from.
-         -> Int32 -- ^ __size__: specifies the number of elements of the first dimension
-                            -- of 'input' to slice. If size is -1, all remaining elements in the dimension
-                            -- are included in the slice (i.e. this is equivalent to setting
-                            -- size = input.dim_size(0) - begin).
+         => Tensor v1 t    -- ^ __input__
+         -> Int32          -- ^ __begin__: specifies the offset into the first dimension of
+                           -- 'input' to slice from.
+         -> Int32          -- ^ __size__: specifies the number of elements of the first dimension
+                           -- of 'input' to slice. If size is -1, all remaining elements in the dimension
+                           -- are included in the slice (i.e. this is equivalent to setting
+                           -- size = input.dim_size(0) - begin).
          -> Tensor Value t -- ^ __output__
 flatSlice input begin size = CoreOps.slice input (vector [begin]) (vector [size])
 
@@ -446,9 +446,9 @@ opGrad "Gather" _ [toT -> x, toT -> indices] [dz] =
   where
     -- TODO(gnezdo): Use colocateWith but it requires Build monad.
     denseShape = shape (x :: Tensor Value a)
-    numRows = scalarize $ flatSlice denseShape (0 :: Int32) 1
+    numRows = scalarize $ flatSlice denseShape 0 1
     valuesShape = CoreOps.concat 0 [ allDimensions
-                                   , flatSlice denseShape 1 (-1 :: Int32)
+                                   , flatSlice denseShape 1 (-1)
                                    ]
     values = reshape dz valuesShape
     -- TODO(fmayle): This could be either Int32 or Int64.
@@ -643,7 +643,7 @@ opGrad "SparseSegmentSum" _ [toT -> x, toT -> y, toT -> t] [dz] =
     , Nothing
     , Nothing
     ]
-  where inputRows = flatSlice (shape (x :: Tensor Value a)) (0 :: Int32) 1
+  where inputRows = flatSlice (shape (x :: Tensor Value a)) 0 1
 
 opGrad "LabelClasses" _ _ _ = [Nothing, Nothing]
 opGrad "LabelWeights" _ _ _ = [Nothing]

--- a/tensorflow-ops/src/TensorFlow/Gradient.hs
+++ b/tensorflow-ops/src/TensorFlow/Gradient.hs
@@ -406,11 +406,11 @@ toT = Tensor ValueKind
 
 -- | Wrapper around `TensorFlow.GenOps.Core.slice` that builds vectors from scalars for
 -- simple slicing operations.
-flatSlice :: forall v1 t i . (TensorType t, OneOf '[Int32, Int64] i)
+flatSlice :: forall v1 t i . (TensorType t)
          => Tensor v1 t -- ^ __input__
-         -> i -- ^ __begin__: specifies the offset into the first dimension of
+         -> Int32 -- ^ __begin__: specifies the offset into the first dimension of
                             -- 'input' to slice from.
-         -> i -- ^ __size__: specifies the number of elements of the first dimension
+         -> Int32 -- ^ __size__: specifies the number of elements of the first dimension
                             -- of 'input' to slice. If size is -1, all remaining elements in the dimension
                             -- are included in the slice (i.e. this is equivalent to setting
                             -- size = input.dim_size(0) - begin).

--- a/tensorflow-ops/src/TensorFlow/Ops.hs
+++ b/tensorflow-ops/src/TensorFlow/Ops.hs
@@ -260,9 +260,7 @@ constant (Shape shape') values
 -- | Reshape a N-D tensor down to a scalar.
 -- 
 -- See `TensorFlow.GenOps.Core.reshape`.
-scalarize :: (TensorType a) 
-         => Tensor v a 
-         -> Tensor Value a
+scalarize :: (TensorType a) => Tensor v a -> Tensor Value a
 scalarize t = CoreOps.reshape t (vector scalarShape)
     where
         scalarShape = [] :: [Int32]

--- a/tensorflow-ops/src/TensorFlow/Ops.hs
+++ b/tensorflow-ops/src/TensorFlow/Ops.hs
@@ -101,6 +101,7 @@ module TensorFlow.Ops
     , vector
     , zeros
     , CoreOps.zerosLike
+    , toScalar
     ) where
 
 import Data.ByteString (ByteString)
@@ -255,6 +256,15 @@ constant (Shape shape') values
                 & tensorShape.TensorShape.dim .~
                       [def & TensorShape.size .~ x | x <- shape']
                 & tensorVal .~ values
+
+-- | Reshape a N-D tensor down to a scalar.
+toScalar :: (TensorType a) 
+         => Tensor v a 
+         -> Tensor Value a
+toScalar = flip CoreOps.reshape (vector scalarShape)
+    where
+        scalarShape = [] :: [Int32]
+
 
 -- | Create a constant vector.
 vector :: TensorType a => [a] -> Tensor Value a

--- a/tensorflow-ops/src/TensorFlow/Ops.hs
+++ b/tensorflow-ops/src/TensorFlow/Ops.hs
@@ -101,7 +101,7 @@ module TensorFlow.Ops
     , vector
     , zeros
     , CoreOps.zerosLike
-    , toScalar
+    , scalarize
     ) where
 
 import Data.ByteString (ByteString)
@@ -258,10 +258,12 @@ constant (Shape shape') values
                 & tensorVal .~ values
 
 -- | Reshape a N-D tensor down to a scalar.
-toScalar :: (TensorType a) 
+-- 
+-- See `TensorFlow.GenOps.Core.reshape`.
+scalarize :: (TensorType a) 
          => Tensor v a 
          -> Tensor Value a
-toScalar = flip CoreOps.reshape (vector scalarShape)
+scalarize t = CoreOps.reshape t (vector scalarShape)
     where
         scalarShape = [] :: [Int32]
 

--- a/tensorflow-ops/tensorflow-ops.cabal
+++ b/tensorflow-ops/tensorflow-ops.cabal
@@ -60,6 +60,7 @@ Test-Suite EmbeddingOpsTest
                , lens-family
                , google-shim
                , tensorflow
+               , tensorflow-test
                , tensorflow-core-ops
                , tensorflow-ops
                , tensorflow-proto

--- a/tensorflow-ops/tests/EmbeddingOpsTest.hs
+++ b/tensorflow-ops/tests/EmbeddingOpsTest.hs
@@ -46,16 +46,17 @@ buildAndRun = TF.runSession . TF.buildAnd TF.run
 
 
 -- | Tries to perform a simple embedding lookup, with two partitions.
-testEmbeddingLookupHasRightShapeWithPartition = testCase "testEmbeddingLookupHasRightShapeWithPartition" $ do
+testEmbeddingLookupHasRightShapeWithPartition = 
+        testCase "testEmbeddingLookupHasRightShapeWithPartition" $ do
     let shape       = TF.Shape [1, 3] -- Consider a 3-dim embedding of two items.
-    let embedding1  = [ 1, 1, 1 ] :: [Int32]
-    let embedding2  = [ 0, 0, 0 ] :: [Int32]
+    let embedding1  = [ 1, 1, 1 :: Int32]
+    let embedding2  = [ 0, 0, 0 :: Int32]
 
     let embedding = [ TF.constant shape embedding1
                     , TF.constant shape embedding2
                     ]
 
-    let idValues  = [0, 1] :: [Int32]
+    let idValues  = [0, 1 :: Int32]
     let ids       = TF.constant (TF.Shape [1, 2]) idValues
     let op        = embeddingLookup embedding ids
 
@@ -77,7 +78,7 @@ testEmbeddingLookupHasRightShape = testCase "testEmbeddingLookupHasRightShape" $
                         , 0, 0, 0 ] :: [Int32]
 
     let embedding = TF.constant shape embeddingInit
-    let idValues  = [0, 1] :: [Int32]
+    let idValues  = [0, 1 :: Int32]
     let ids       = TF.constant (TF.Shape [1, 2]) idValues
     let op        = embeddingLookup [embedding] ids
 
@@ -94,32 +95,29 @@ testEmbeddingLookupHasRightShape = testCase "testEmbeddingLookupHasRightShape" $
 
 -- | Check that we can calculate gradients w.r.t embeddings.
 testEmbeddingLookupGradients = testCase "testEmbeddingLookupGradients" $ do
-    let xVals = V.fromList ([20, 20] :: [Float]) -- Agrees with "embedding", so gradient should be zero.
+    -- Agrees with "embedding", so gradient should be zero.
+    let xVals = V.fromList ([20, 20 :: Float])
     let shape = TF.Shape [2]
 
     gs <- TF.runSession $ do
         grads <- TF.build $ do
             let shape         = TF.Shape [2, 1] 
-            let embeddingInit = [1, 20] :: [Float]
-            let idValues      = [1, 1]   :: [Int32]
+            let embeddingInit = [1, 20 ::Float]
+            let idValues      = [1, 1 :: Int32]
             let ids           = TF.constant (TF.Shape [1, 2]) idValues
 
             x <- TF.placeholder (TF.Shape [2]) 
-            embedding <- TF.initializedVariable =<< (TF.render $ TF.constant shape embeddingInit)
+            embedding <- TF.initializedVariable =<< TF.render (TF.constant shape embeddingInit)
             
             op <- embeddingLookup [embedding] ids
             let loss = TF.mean (CoreOps.square (TF.abs (op - x))) (TF.scalar (0 :: Int32))
 
             grad <- fmap head (TF.gradients loss [embedding])
-
             return $ \xs -> TF.runWithFeeds [TF.feed x xs] grad
 
         grads (TF.encodeTensorData shape xVals :: TF.TensorData Float)
- 
     -- Gradients should be zero (or close)
-    assertAllClose gs (V.fromList ([0, 0] :: [Float]))
-
-
+    assertAllClose gs (V.fromList ([0, 0 :: Float]))
 
 
 -- Verifies that direct gather is the same as dynamic split into

--- a/tensorflow-ops/tests/EmbeddingOpsTest.hs
+++ b/tensorflow-ops/tests/EmbeddingOpsTest.hs
@@ -28,6 +28,7 @@ import Test.HUnit ((@=?), (@?))
 import Test.Framework.Providers.HUnit (testCase)
 import Test.QuickCheck (Arbitrary(..), Property, choose, vectorOf)
 import Test.QuickCheck.Monadic (monadicIO, run)
+import TensorFlow.Test (assertAllClose)
 
 import qualified Data.Vector as V
 import qualified TensorFlow.GenOps.Core as CoreOps
@@ -119,15 +120,6 @@ testEmbeddingLookupGradients = testCase "testEmbeddingLookupGradients" $ do
     assertAllClose gs (V.fromList ([0, 0] :: [Float]))
 
 
--- TODO: Move this out into a central testing utils lib and remove from NN
--- tests
-assertAllClose :: V.Vector Float -> V.Vector Float -> Assertion
-assertAllClose xs ys = all (<= tol) (V.zipWith absDiff xs ys) @?
-    ("Difference > tolerance: \nxs: " ++ show xs ++ "\nys: " ++ show ys
-        ++ "\ntolerance: " ++ show tol)
-  where
-      absDiff x y = abs (x - y)
-      tol = 0.001 :: Float
 
 
 -- Verifies that direct gather is the same as dynamic split into

--- a/tensorflow-ops/tests/EmbeddingOpsTest.hs
+++ b/tensorflow-ops/tests/EmbeddingOpsTest.hs
@@ -93,14 +93,14 @@ testEmbeddingLookupHasRightShape = testCase "testEmbeddingLookupHasRightShape" $
 
 -- | Check that we can calculate gradients w.r.t embeddings.
 testEmbeddingLookupGradients = testCase "testEmbeddingLookupGradients" $ do
-    let xVals = V.fromList ([10, 20] :: [Float]) -- Same as "embedding", so gradient should be zero.
+    let xVals = V.fromList ([20, 20] :: [Float]) -- Agrees with "embedding", so gradient should be zero.
     let shape = TF.Shape [2]
 
     gs <- TF.runSession $ do
         grads <- TF.build $ do
             let shape         = TF.Shape [2, 1] 
-            let embeddingInit = [10, 20] :: [Float]
-            let idValues      = [0, 1] :: [Int32]
+            let embeddingInit = [1, 20] :: [Float]
+            let idValues      = [1, 1]   :: [Int32]
             let ids           = TF.constant (TF.Shape [1, 2]) idValues
 
             x <- TF.placeholder (TF.Shape [2]) 

--- a/tensorflow-test/Setup.hs
+++ b/tensorflow-test/Setup.hs
@@ -1,0 +1,3 @@
+import Distribution.Simple
+
+main = defaultMain

--- a/tensorflow-test/src/TensorFlow/Test.hs
+++ b/tensorflow-test/src/TensorFlow/Test.hs
@@ -1,0 +1,34 @@
+-- Copyright 2016 TensorFlow authors.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{-# LANGUAGE OverloadedStrings #-}
+
+module TensorFlow.Test
+    ( assertAllClose
+    ) where
+
+import Test.HUnit.Lang (Assertion(..))
+import qualified Data.Vector as V
+import Test.HUnit ((@?))
+
+-- | Compares that the vectors are element-by-element equal within the given
+-- tolerance. Raises an assertion and prints some information if not.
+assertAllClose :: V.Vector Float -> V.Vector Float -> Assertion
+assertAllClose xs ys = all (<= tol) (V.zipWith absDiff xs ys) @?
+    ("Difference > tolerance: \nxs: " ++ show xs ++ "\nys: " ++ show ys
+        ++ "\ntolerance: " ++ show tol)
+  where
+      absDiff x y = abs (x - y)
+      tol = 0.001 :: Float
+

--- a/tensorflow-test/src/TensorFlow/Test.hs
+++ b/tensorflow-test/src/TensorFlow/Test.hs
@@ -18,16 +18,16 @@ module TensorFlow.Test
     ( assertAllClose
     ) where
 
-import Test.HUnit.Lang (Assertion(..))
 import qualified Data.Vector as V
 import Test.HUnit ((@?))
+import Test.HUnit.Lang (Assertion(..))
 
 -- | Compares that the vectors are element-by-element equal within the given
 -- tolerance. Raises an assertion and prints some information if not.
 assertAllClose :: V.Vector Float -> V.Vector Float -> Assertion
 assertAllClose xs ys = all (<= tol) (V.zipWith absDiff xs ys) @?
-    ("Difference > tolerance: \nxs: " ++ show xs ++ "\nys: " ++ show ys
-        ++ "\ntolerance: " ++ show tol)
+    "Difference > tolerance: \nxs: " ++ show xs ++ "\nys: " ++ show ys
+        ++ "\ntolerance: " ++ show tol
   where
       absDiff x y = abs (x - y)
       tol = 0.001 :: Float

--- a/tensorflow-test/tensorflow-test.cabal
+++ b/tensorflow-test/tensorflow-test.cabal
@@ -1,0 +1,25 @@
+name:                tensorflow-test
+version:             0.1.0.0
+synopsis:            Friendly layer around TensorFlow bindings.
+description:         Please see README.md
+homepage:            https://github.com/tensorflow/haskell#readme
+license:             Apache
+author:              TensorFlow authors
+maintainer:          tensorflow-haskell@googlegroups.com
+copyright:           Google Inc.
+category:            Machine Learning
+build-type:          Simple
+cabal-version:       >=1.22
+
+library
+  hs-source-dirs:   src
+  exposed-modules: TensorFlow.Test
+  build-depends:  base >= 4.7 && < 5
+                , HUnit
+                , vector
+  default-language:    Haskell2010
+
+
+source-repository head
+  type:     git
+  location: https://github.com/tensorflow/haskell

--- a/tensorflow-test/tensorflow-test.cabal
+++ b/tensorflow-test/tensorflow-test.cabal
@@ -1,7 +1,6 @@
 name:                tensorflow-test
 version:             0.1.0.0
-synopsis:            Friendly layer around TensorFlow bindings.
-description:         Please see README.md
+synopsis:            Some common functions for test suites.
 homepage:            https://github.com/tensorflow/haskell#readme
 license:             Apache
 author:              TensorFlow authors


### PR DESCRIPTION
i've noticed that i don't seem to be able to calculate the gradient w.r.t an embedding, this is the error:

```
ERROR: TensorFlowException TF_INVALID_ARGUMENT "Expected begin and size arguments to be 1-D tensors of size 1, but got shapes [] and [] instead.

 [[Node: Slice_54 = Slice[Index=DT_INT32, T=DT_INT32, _device=\"/job:localhost/replica:0/task:0/cpu:0\"](Shape_52, Const_18, Neg_53)]]"
```

the equivalent python code to the following test works (but i note that in python i can *also* calculate the gradient w.r.t say the variable named below called `op` that is a `Tensor Value` not a `Tensor Ref`; i.e. it's a type error)

i'm looking for a bit of guidance here. i'm fairly sure i should be able to calculate the gradient like this. but i could be convinced/shown that i'm doing it wrong, and there's a different way to get the embedding vars to gradient application ...

interested in thoughts.

if we do keep this test, i should first make a bit of a test lib and put some funtions in there (namely the `assertAllClose`...)

(sidenote: i'm having a truly terrible time with shape instances/Int32s/etc, so i'll one day try and figure out how to clean all that up; maybe i'm just missing some imports or some philosophical viewpoint)