### PR TITLE
Optimize fetching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/.stack-work
 .stack/
+tensorflow-mnist-input-data/data/*.gz

--- a/tensorflow-ops/tensorflow-ops.cabal
+++ b/tensorflow-ops/tensorflow-ops.cabal
@@ -187,6 +187,14 @@ Test-Suite TypesTest
                , test-framework-quickcheck2
                , vector
 
+Benchmark FeedFetchBench
+  default-language: Haskell2010
+  type:       exitcode-stdio-1.0
+  main-is:    FeedFetchBench.hs
+  hs-source-dirs: tests
+  build-depends: base, criterion, tensorflow, tensorflow-ops, vector, transformers
+  ghc-options: -O2 -threaded
+
 source-repository head
   type:     git
   location: https://github.com/tensorflow/haskell

--- a/tensorflow-ops/tensorflow-ops.cabal
+++ b/tensorflow-ops/tensorflow-ops.cabal
@@ -192,7 +192,13 @@ Benchmark FeedFetchBench
   type:       exitcode-stdio-1.0
   main-is:    FeedFetchBench.hs
   hs-source-dirs: tests
-  build-depends: base, criterion, tensorflow, tensorflow-ops, vector, transformers
+  build-depends: base
+               , criterion
+               , deepseq
+               , tensorflow
+               , tensorflow-ops
+               , transformers
+               , vector
   ghc-options: -O2 -threaded
 
 source-repository head

--- a/tensorflow-ops/tests/FeedFetchBench.hs
+++ b/tensorflow-ops/tests/FeedFetchBench.hs
@@ -1,31 +1,25 @@
 -- Disable full-laziness to keep ghc from optimizing most of the benchmark away.
 {-# OPTIONS_GHC -fno-full-laziness #-}
+import Control.DeepSeq (NFData(rnf))
 import Control.Exception (evaluate)
-import Control.Monad (replicateM_)
 import Control.Monad.IO.Class (liftIO)
-import Criterion.Main (defaultMain, bgroup, bench, nfIO)
+import Criterion.Main (defaultMain, bgroup, bench)
 import Criterion.Types (Benchmarkable(..))
 import qualified Data.Vector as V
-import qualified TensorFlow.Build as TF
-import qualified TensorFlow.ControlFlow as TF
-import qualified TensorFlow.Gradient as TF
-import qualified TensorFlow.Nodes as TF
+import qualified TensorFlow.Core as TF
 import qualified TensorFlow.Ops as TF
-import qualified TensorFlow.Session as TF
-import qualified TensorFlow.Tensor as TF
-import qualified TensorFlow.Types as TF
 
 -- | Create 'Benchmarkable' for 'TF.Session'.
 --
 -- The entire benchmark will be run in a single tensorflow session. The
 -- 'TF.Session' argument will be run once and then its result will be run N
 -- times.
-whnfSession :: TF.Session (a -> TF.Session b) -> a -> Benchmarkable
-whnfSession init x = Benchmarkable $ \m -> TF.runSession $ do
+nfSession :: NFData b => TF.Session (a -> TF.Session b) -> a -> Benchmarkable
+nfSession init x = Benchmarkable $ \m -> TF.runSession $ do
     f <- init
     -- Can't use replicateM because n is Int64.
     let go n | n <= 0    = return ()
-             | otherwise = f x >>= liftIO . evaluate >> go (n-1)
+             | otherwise = f x >>= liftIO . evaluate . rnf >> go (n-1)
     go m
 
 -- | Benchmark feeding and fetching a vector.
@@ -42,8 +36,8 @@ feedFetchBenchmark = do
 main :: IO ()
 main = defaultMain
     [ bgroup "feedFetch"
-        [ bench "4 byte" $ whnfSession feedFetchBenchmark (V.replicate 1 0)
-        , bench "4 KiB" $ whnfSession feedFetchBenchmark (V.replicate 1024 0)
-        , bench "4 MiB" $ whnfSession feedFetchBenchmark (V.replicate (1024^2) 0)
+        [ bench "4 byte" $ nfSession feedFetchBenchmark (V.replicate 1 0)
+        , bench "4 KiB" $ nfSession feedFetchBenchmark (V.replicate 1024 0)
+        , bench "4 MiB" $ nfSession feedFetchBenchmark (V.replicate (1024^2) 0)
         ]
     ]

--- a/tensorflow-ops/tests/FeedFetchBench.hs
+++ b/tensorflow-ops/tests/FeedFetchBench.hs
@@ -1,0 +1,49 @@
+-- Disable full-laziness to keep ghc from optimizing most of the benchmark away.
+{-# OPTIONS_GHC -fno-full-laziness #-}
+import Control.Exception (evaluate)
+import Control.Monad (replicateM_)
+import Control.Monad.IO.Class (liftIO)
+import Criterion.Main (defaultMain, bgroup, bench, nfIO)
+import Criterion.Types (Benchmarkable(..))
+import qualified Data.Vector as V
+import qualified TensorFlow.Build as TF
+import qualified TensorFlow.ControlFlow as TF
+import qualified TensorFlow.Gradient as TF
+import qualified TensorFlow.Nodes as TF
+import qualified TensorFlow.Ops as TF
+import qualified TensorFlow.Session as TF
+import qualified TensorFlow.Tensor as TF
+import qualified TensorFlow.Types as TF
+
+-- | Create 'Benchmarkable' for 'TF.Session'.
+--
+-- The entire benchmark will be run in a single tensorflow session. The
+-- 'TF.Session' argument will be run once and then its result will be run N
+-- times.
+whnfSession :: TF.Session (a -> TF.Session b) -> a -> Benchmarkable
+whnfSession init x = Benchmarkable $ \m -> TF.runSession $ do
+    f <- init
+    -- Can't use replicateM because n is Int64.
+    let go n | n <= 0    = return ()
+             | otherwise = f x >>= liftIO . evaluate >> go (n-1)
+    go m
+
+-- | Benchmark feeding and fetching a vector.
+feedFetchBenchmark :: TF.Session (V.Vector Float -> TF.Session (V.Vector Float))
+feedFetchBenchmark = do
+    input <- TF.build (TF.placeholder (TF.Shape [-1]))
+    output <- TF.build (TF.render (TF.identity input))
+    return $ \v -> do
+        let shape = TF.Shape [fromIntegral (V.length v)]
+            inputData = TF.encodeTensorData shape v
+            feeds = [TF.feed input inputData]
+        TF.runWithFeeds feeds output
+
+main :: IO ()
+main = defaultMain
+    [ bgroup "feedFetch"
+        [ bench "4 byte" $ whnfSession feedFetchBenchmark (V.replicate 1 0)
+        , bench "4 KiB" $ whnfSession feedFetchBenchmark (V.replicate 1024 0)
+        , bench "4 MiB" $ whnfSession feedFetchBenchmark (V.replicate (1024^2) 0)
+        ]
+    ]

--- a/tensorflow/src/TensorFlow/Internal/FFI.hs
+++ b/tensorflow/src/TensorFlow/Internal/FFI.hs
@@ -14,6 +14,7 @@
 
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module TensorFlow.Internal.FFI
     ( TensorFlowException(..)
@@ -34,7 +35,10 @@ import Control.Concurrent.Async (Async, async, cancel, waitCatch)
 import Control.Concurrent.MVar (MVar, modifyMVarMasked_, newMVar, takeMVar)
 import Control.Exception (Exception, throwIO, bracket, finally, mask_)
 import Control.Monad (when)
+import Data.Bits (Bits, toIntegralSized)
+import Data.Data (Data, dataTypeName, dataTypeOf)
 import Data.Int (Int64)
+import Data.Maybe (fromMaybe)
 import Data.Typeable (Typeable)
 import Data.Word (Word8)
 import Foreign (Ptr, FunPtr, nullPtr, castPtr)
@@ -134,15 +138,26 @@ run session feeds fetches targets = do
             checkStatus $ Raw.run
                 session
                 nullPtr
-                feedNames cFeedTensors (fromIntegral feedsLen)
-                fetchNames tensorOuts (fromIntegral fetchesLen)
-                ctargets (fromIntegral targetsLen)
+                feedNames cFeedTensors (safeConvert feedsLen)
+                fetchNames tensorOuts (safeConvert fetchesLen)
+                ctargets (safeConvert targetsLen)
                 nullPtr
             outTensors <- peekArray fetchesLen tensorOuts
             mapM createTensorData outTensors
 
 
 -- Internal.
+
+
+-- | Same as 'fromIntegral', but throws an error if conversion is "lossy".
+safeConvert ::
+    forall a b. (Show a, Show b, Bits a, Bits b, Integral a, Integral b)
+    => a -> b
+safeConvert x =
+    fromMaybe
+    (error ("Failed to convert " ++ show x ++ ", got " ++
+            show (fromIntegral x :: b)))
+    (toIntegralSized x)
 
 
 -- | Use a list of ByteString as a list of CString.
@@ -162,13 +177,13 @@ withStringArrayLen xs fn = withStringList xs (`withArrayLen` fn)
 -- | Create a Raw.Tensor from a TensorData.
 createRawTensor :: TensorData -> IO Raw.Tensor
 createRawTensor (TensorData dims dt byteVec) =
-    withArrayLen (map fromIntegral dims) $ \cdimsLen cdims -> do
+    withArrayLen (map safeConvert dims) $ \cdimsLen cdims -> do
         let len = S.length byteVec
         dest <- mallocArray len
         S.unsafeWith byteVec $ \x -> copyArray dest x len
         Raw.newTensor (toEnum $ fromEnum dt)
-                      cdims (fromIntegral cdimsLen)
-                      (castPtr dest) (fromIntegral len)
+                      cdims (safeConvert cdimsLen)
+                      (castPtr dest) (safeConvert len)
                       tensorDeallocFunPtr nullPtr
 
 {-# NOINLINE tensorDeallocFunPtr #-}
@@ -186,7 +201,7 @@ createTensorData t = do
     -- Read type.
     dtype <- toEnum . fromEnum <$> Raw.tensorType t
     -- Read data.
-    len <- fromIntegral <$> Raw.tensorByteSize t
+    len <- safeConvert <$> Raw.tensorByteSize t
     bytes <- castPtr <$> Raw.tensorData t :: IO (Ptr Word8)
     -- Note: We would like to avoid the copy by creating an S.Vector directly
     -- from 'bytes' and calling Raw.deleteTensor when it gets GC'd, but we can't
@@ -196,7 +211,7 @@ createTensorData t = do
     v <- S.unsafeFreeze mv
     -- Free tensor.
     Raw.deleteTensor t
-    return $ TensorData (map fromIntegral dims) dtype v
+    return $ TensorData (map safeConvert dims) dtype v
 
 -- | Runs the given action which does FFI calls updating a provided
 -- status object. If the status is not OK it is thrown as
@@ -222,10 +237,10 @@ setSessionTarget target = B.useAsCString target . Raw.setTarget
 
 -- | Serializes the given msg and provides it as (ptr,len) argument
 -- to the given action.
-useProtoAsVoidPtrLen :: (Message msg, Num c) =>
+useProtoAsVoidPtrLen :: (Message msg, Integral c, Show c, Bits c) =>
                         msg -> (Ptr b -> c -> IO a) -> IO a
 useProtoAsVoidPtrLen msg f = B.useAsCStringLen (encodeMessage msg) $
-        \(bytes, len) -> f (castPtr bytes) (fromIntegral len)
+        \(bytes, len) -> f (castPtr bytes) (safeConvert len)
 
 -- | Returns the serialized OpList of all OpDefs defined in this
 -- address space.
@@ -238,7 +253,7 @@ getAllOpList = do
     withForeignPtr foreignPtr $
         \ptr -> B.packCStringLen =<< (,)
                 <$> (castPtr <$> Raw.getBufferData ptr)
-                <*> (fromIntegral <$> Raw.getBufferLength ptr)
+                <*> (safeConvert <$> Raw.getBufferLength ptr)
     where
       checkCall = do
           p <- Raw.getAllOpList

--- a/tensorflow/src/TensorFlow/Internal/FFI.hs
+++ b/tensorflow/src/TensorFlow/Internal/FFI.hs
@@ -48,6 +48,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.Encoding.Error as T
 import qualified Data.Vector.Storable as S
+import qualified Data.Vector.Storable.Mutable as SM
 
 import Data.ProtoLens (Message, encodeMessage)
 import Proto.Tensorflow.Core.Framework.Graph (GraphDef)
@@ -187,8 +188,12 @@ createTensorData t = do
     -- Read data.
     len <- fromIntegral <$> Raw.tensorByteSize t
     bytes <- castPtr <$> Raw.tensorData t :: IO (Ptr Word8)
-    -- TODO(fmayle): Don't copy the data.
-    v <- S.fromList <$> peekArray len bytes
+    -- Note: We would like to avoid the copy by creating an S.Vector directly
+    -- from 'bytes' and calling Raw.deleteTensor when it gets GC'd, but we can't
+    -- because the vector may outlive the tensorflow session and become invalid.
+    mv <- SM.new len
+    SM.unsafeWith mv $ \dest -> copyArray dest bytes len
+    v <- S.unsafeFreeze mv
     -- Free tensor.
     Raw.deleteTensor t
     return $ TensorData (map fromIntegral dims) dtype v


### PR DESCRIPTION
# Before

```
benchmarking feedFetch/4 byte
time                 56.07 μs   (54.64 μs .. 57.31 μs)
                     0.995 R²   (0.993 R² .. 0.997 R²)
mean                 57.66 μs   (56.57 μs .. 58.74 μs)
std dev              3.851 μs   (3.350 μs .. 4.642 μs)
variance introduced by outliers: 68% (severely inflated)

benchmarking feedFetch/4 KiB
time                 228.8 μs   (227.4 μs .. 230.3 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 229.1 μs   (228.5 μs .. 230.5 μs)
std dev              3.016 μs   (1.902 μs .. 5.111 μs)

benchmarking feedFetch/4 MiB
time                 596.5 ms   (457.2 ms .. 661.2 ms)
                     0.994 R²   (0.984 R² .. 1.000 R²)
mean                 569.8 ms   (536.0 ms .. 589.7 ms)
std dev              30.62 ms   (0.0 s .. 34.45 ms)
variance introduced by outliers: 19% (moderately inflated)
```


# After

```
benchmarking feedFetch/4 byte
time                 58.26 μs   (57.03 μs .. 59.75 μs)
                     0.996 R²   (0.993 R² .. 0.998 R²)
mean                 61.08 μs   (59.17 μs .. 65.55 μs)
std dev              9.397 μs   (4.998 μs .. 17.20 μs)
variance introduced by outliers: 93% (severely inflated)

benchmarking feedFetch/4 KiB
time                 96.54 μs   (96.08 μs .. 97.07 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 97.85 μs   (97.21 μs .. 98.96 μs)
std dev              2.595 μs   (1.807 μs .. 4.076 μs)
variance introduced by outliers: 23% (moderately inflated)

benchmarking feedFetch/4 MiB
time                 126.0 ms   (125.4 ms .. 127.3 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 127.5 ms   (127.1 ms .. 128.0 ms)
std dev              720.2 μs   (580.4 μs .. 882.0 μs)
variance introduced by outliers: 11% (moderately inflated)
```