### PR TITLE
Uprev tensorflow.

### DIFF
--- a/tensorflow-core-ops/Setup.hs
+++ b/tensorflow-core-ops/Setup.hs
@@ -75,6 +75,7 @@ blackList =
     , "QueueDequeueUpTo"
     , "Stack"
     , "TensorArray"
+    , "TensorArrayV2"
       -- These should be possible to support by adding a bunch of
       -- overloads with a variable number of tuple arguments.
     , "Assert"
@@ -99,7 +100,4 @@ blackList =
     , "_ListToArray"
       -- Easy: support larger result tuples.
     , "Skipgram"
-    -- Can be removed after 139136489 is released.
-    , "ResourceGather"
-    , "ResourceScatterAdd"
     ]

--- a/tensorflow/src/TensorFlow/Internal/FFI.hs
+++ b/tensorflow/src/TensorFlow/Internal/FFI.hs
@@ -137,6 +137,7 @@ run session feeds fetches targets = do
                 fetchNames tensorOuts (fromIntegral fetchesLen)
                 ctargets (fromIntegral targetsLen)
                 nullPtr
+            mapM_ Raw.deleteTensor feedTensors
             outTensors <- peekArray fetchesLen tensorOuts
             mapM createTensorData outTensors
 


### PR DESCRIPTION
* No longer need to hide ResourceHandle ops
* Blacklisted not supported TensorArrayV2
* Ownership of feed tensors changed (TF commit 1f0c5119a0230c5160d45496175b9256f097e144)