### PR TITLE
Fix the build on ghc-8.0.1 (#38).

### DIFF
--- a/tensorflow-core-ops/tensorflow-core-ops.cabal
+++ b/tensorflow-core-ops/tensorflow-core-ops.cabal
@@ -24,6 +24,10 @@ library
                 , lens-family
                 , text
   default-language:    Haskell2010
+  -- Work around https://ghc.haskell.org/trac/ghc/ticket/12175.
+  if impl(ghc >= 8) {
+    ghc-options: -fconstraint-solver-iterations=0
+  }
 
 source-repository head
   type:     git

--- a/tensorflow-nn/tensorflow-nn.cabal
+++ b/tensorflow-nn/tensorflow-nn.cabal
@@ -19,6 +19,10 @@ library
                 , tensorflow == 0.1.*
                 , tensorflow-ops == 0.1.*
   default-language:    Haskell2010
+  -- Work around https://ghc.haskell.org/trac/ghc/ticket/12175.
+  if impl(ghc >= 8) {
+    ghc-options: -fconstraint-solver-iterations=0
+  }
 
 
 Test-Suite NNTest

--- a/tensorflow-ops/tensorflow-ops.cabal
+++ b/tensorflow-ops/tensorflow-ops.cabal
@@ -29,6 +29,10 @@ library
                 , tensorflow-core-ops == 0.1.*
                 , text
   default-language:    Haskell2010
+  -- Work around https://ghc.haskell.org/trac/ghc/ticket/12175.
+  if impl(ghc >= 8) {
+    ghc-options: -fconstraint-solver-iterations=0
+  }
 
 Test-Suite BuildTest
   default-language: Haskell2010
@@ -202,6 +206,11 @@ Test-Suite TypesTest
                , test-framework-hunit
                , test-framework-quickcheck2
                , vector
+  -- Work around https://ghc.haskell.org/trac/ghc/ticket/12175,
+  -- since this test defines its own ops.
+  if impl(ghc >= 8) {
+    ghc-options: -fconstraint-solver-iterations=0
+  }
 
 Benchmark FeedFetchBench
   default-language: Haskell2010

--- a/tensorflow/src/TensorFlow/Types.hs
+++ b/tensorflow/src/TensorFlow/Types.hs
@@ -373,7 +373,7 @@ type family Delete a as where
 -- | Takes the difference of two lists of types.
 type family as \\ bs where
     as \\ '[] = as
-    as \\ b ': bs = Delete b as \\ bs
+    as \\ (b ': bs) = Delete b as \\ bs
 
 -- | A constraint that the type @a@ doesn't appear in the type list @ts@.
 -- Assumes that @a@ and each of the elements of @ts@ are 'TensorType's.


### PR DESCRIPTION
Two issues:
- The definition of `\\` was missing parentheses.  It was probably a bug
  that this used to worked in ghc-7.10.
- Set -fconstraint-solver-iterations=0 to work around
  https://ghc.haskell.org/trac/ghc/ticket/12175.  It looks like we can
  trigger that bug when defining a significantly complicated op.  Specifically,
  our type shenanigans ("OneOf") along with lens setters (for OpDef) seem
  to confuse GHC.

Still TODO: automate testing of different ghc versions to prevent a regression.