### PR TITLE
Make GHC 8 build succeed

### DIFF
--- a/tensorflow/src/TensorFlow/Types.hs
+++ b/tensorflow/src/TensorFlow/Types.hs
@@ -373,7 +373,7 @@ type family Delete a as where
 -- | Takes the difference of two lists of types.
 type family as \\ bs where
     as \\ '[] = as
-    as \\ b ': bs = Delete b as \\ bs
+    as \\ (b ': bs) = Delete b as \\ bs
 
 -- | A constraint that the type @a@ doesn't appear in the type list @ts@.
 -- Assumes that @a@ and each of the elements of @ts@ are 'TensorType's.


### PR DESCRIPTION
I've adjusted one parenthesis and it seem to be working on GHC 8.0.1.
`-fconstraint-solver-iterations=0` flag is also needed to workaround following failure:
```
solveWanteds: too many iterations (limit = 4)
```
So concretely the build command looked like this:
```
stack --resolver lts-7.9 test --ghc-options -fconstraint-solver-iterations=0
```

FYI, due to commercialhaskell/stack#2712, currently stack's GHC does not work for some system (mine included), so it can be handy.

cc: #38 