### PR TITLE
Add instructions to symlink ".so" to ".dylib" on OS X (#42).

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The following instructions were verified with Mac OS X El Capitan.
         ./configure  # Choose the defaults when prompted
         bazel build -c opt tensorflow:libtensorflow_c.so
         install bazel-bin/tensorflow/libtensorflow_c.so /usr/local/lib
+        ln -s /usr/local/lib/libtensorflow_c.{so,dylib}
         cd ../..
 
 - Run stack:


### PR DESCRIPTION
I'm not sure why, but in some cases it seems linking only works if *both* the
.so and the .dylib are present in /usr/local/lib.  This may be due to a quirk
of how Bazel builds the library, and/or how ghc/stack load the library.