### PR TITLE
Update OS X instructions (#42) to not require a separate ".so" file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ The following instructions were verified with Mac OS X El Capitan.
         cd third_party/tensorflow
         ./configure  # Choose the defaults when prompted
         bazel build -c opt tensorflow:libtensorflow_c.so
-        install bazel-bin/tensorflow/libtensorflow_c.so /usr/local/lib
-        ln -s /usr/local/lib/libtensorflow_c.{so,dylib}
+        install bazel-bin/tensorflow/libtensorflow_c.so /usr/local/lib/libtensorflow_c.dylib
+        install_name_tool -id libtensorflow_c.dylib /usr/local/lib/libtensorflow_c.dylib
         cd ../..
 
 - Run stack:


### PR DESCRIPTION
The right approach is to run `install_name_tool` on the library after renaming
its extension from ".so" to ".dylib".