### PR TITLE
Add stack resolver version switch (#38).

### DIFF
--- a/ci_build/Dockerfile
+++ b/ci_build/Dockerfile
@@ -11,6 +11,8 @@ MAINTAINER TensorFlow authors <tensorflow-haskell@googlegroups.com>
 ADD . /tfhs
 WORKDIR /tfhs
 
+ARG STACK_RESOLVER
+
 RUN \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 575159689BEFB442 && \
     echo 'deb http://download.fpcomplete.com/ubuntu trusty main'| tee /etc/apt/sources.list.d/fpco.list && \
@@ -30,5 +32,5 @@ RUN \
       bazel build -c opt '//tensorflow:libtensorflow_c.so' && \
       install bazel-bin/tensorflow/libtensorflow_c.so /usr/local/lib && \
       ldconfig ) && \
-    stack setup && \
-    stack test --only-dependencies
+    stack setup --resolver=${STACK_RESOLVER} && \
+    stack test --resolver=${STACK_RESOLVER} --only-dependencies

--- a/ci_build/outer_launch_tests.sh
+++ b/ci_build/outer_launch_tests.sh
@@ -4,8 +4,9 @@
 
 set -eu -o pipefail
 
-IMAGE_NAME=tensorflow/haskell/ci_build:v0
+STACK_RESOLVER=${STACK_RESOLVER:-lts-6.2}
+IMAGE_NAME=tensorflow/haskell/ci_build:$STACK_RESOLVER
 
 git submodule update
-docker build -t $IMAGE_NAME -f ci_build/Dockerfile .
-docker run  $IMAGE_NAME stack build --pedantic --test
+docker build --build-arg STACK_RESOLVER=$STACK_RESOLVER -t $IMAGE_NAME -f ci_build/Dockerfile .
+docker run  $IMAGE_NAME stack build --resolver=$STACK_RESOLVER --pedantic --test

--- a/ci_build/outer_launch_tests.sh
+++ b/ci_build/outer_launch_tests.sh
@@ -9,4 +9,4 @@ IMAGE_NAME=tensorflow/haskell/ci_build:$STACK_RESOLVER
 
 git submodule update
 docker build --build-arg STACK_RESOLVER=$STACK_RESOLVER -t $IMAGE_NAME -f ci_build/Dockerfile .
-docker run  $IMAGE_NAME stack build --resolver=$STACK_RESOLVER --pedantic --test
+docker run $IMAGE_NAME stack build --resolver=$STACK_RESOLVER --pedantic --test


### PR DESCRIPTION
The script can now be run with, e.g.
`env STACK_RESOLVER=lts-7.3 ci_build/outer_launch_tests.sh`
and will use the specified version of the resolver.

We can't quite enable this for lts-7.3 as the code is not pedantically
clean. We will reconsider when 8.0.2 is available which removes
`-Wredundant-constraints` from `-Wall`.