### PR TITLE
Update type constraints to work around a ghc-8 bug.

### DIFF
--- a/tensorflow-core-ops/tensorflow-core-ops.cabal
+++ b/tensorflow-core-ops/tensorflow-core-ops.cabal
@@ -15,6 +15,7 @@ library
   exposed-modules:  TensorFlow.GenOps.Core
   build-depends:  Cabal >= 1.22 && < 1.25
                 , bytestring
+                , directory
                 , proto-lens == 0.1.*
                 , tensorflow-opgen == 0.1.*
                 , tensorflow == 0.1.*
@@ -24,10 +25,6 @@ library
                 , lens-family
                 , text
   default-language:    Haskell2010
-  -- Work around https://ghc.haskell.org/trac/ghc/ticket/12175.
-  if impl(ghc >= 8) {
-    ghc-options: -fconstraint-solver-iterations=0
-  }
 
 source-repository head
   type:     git

--- a/tensorflow-nn/src/TensorFlow/NN.hs
+++ b/tensorflow-nn/src/TensorFlow/NN.hs
@@ -13,6 +13,7 @@
 -- limitations under the License.
 
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module TensorFlow.NN

--- a/tensorflow-nn/tensorflow-nn.cabal
+++ b/tensorflow-nn/tensorflow-nn.cabal
@@ -19,10 +19,6 @@ library
                 , tensorflow == 0.1.*
                 , tensorflow-ops == 0.1.*
   default-language:    Haskell2010
-  -- Work around https://ghc.haskell.org/trac/ghc/ticket/12175.
-  if impl(ghc >= 8) {
-    ghc-options: -fconstraint-solver-iterations=0
-  }
 
 
 Test-Suite NNTest

--- a/tensorflow-opgen/src/TensorFlow/OpGen.hs
+++ b/tensorflow-opgen/src/TensorFlow/OpGen.hs
@@ -117,6 +117,7 @@ docOpList :: OpGenFlags -> OpList -> Doc
 docOpList flags opList =
   stack [ "{-# LANGUAGE ConstraintKinds #-}"
         , "{-# LANGUAGE DataKinds #-}"
+        , "{-# LANGUAGE FlexibleContexts #-}"
         , "{-# LANGUAGE FlexibleInstances #-}"
         , "{-# LANGUAGE OverloadedStrings #-}"
         , "{-# LANGUAGE ScopedTypeVariables #-}"

--- a/tensorflow-ops/src/TensorFlow/EmbeddingOps.hs
+++ b/tensorflow-ops/src/TensorFlow/EmbeddingOps.hs
@@ -14,6 +14,7 @@
 
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}

--- a/tensorflow-ops/src/TensorFlow/Ops.hs
+++ b/tensorflow-ops/src/TensorFlow/Ops.hs
@@ -46,6 +46,7 @@
 -- TensorFlow uses to avoid common subexpression elimination.)
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}

--- a/tensorflow-ops/tensorflow-ops.cabal
+++ b/tensorflow-ops/tensorflow-ops.cabal
@@ -29,10 +29,6 @@ library
                 , tensorflow-core-ops == 0.1.*
                 , text
   default-language:    Haskell2010
-  -- Work around https://ghc.haskell.org/trac/ghc/ticket/12175.
-  if impl(ghc >= 8) {
-    ghc-options: -fconstraint-solver-iterations=0
-  }
 
 Test-Suite BuildTest
   default-language: Haskell2010
@@ -206,11 +202,6 @@ Test-Suite TypesTest
                , test-framework-hunit
                , test-framework-quickcheck2
                , vector
-  -- Work around https://ghc.haskell.org/trac/ghc/ticket/12175,
-  -- since this test defines its own ops.
-  if impl(ghc >= 8) {
-    ghc-options: -fconstraint-solver-iterations=0
-  }
 
 Benchmark FeedFetchBench
   default-language: Haskell2010

--- a/tensorflow-ops/tests/TypesTest.hs
+++ b/tensorflow-ops/tests/TypesTest.hs
@@ -14,6 +14,7 @@
 
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}


### PR DESCRIPTION
Also removes all the ghc-8-specific logic in the .cabal files.

ghc-8 has issues with deeply nested tuples of constraints.  We can
work around it by:
- Changing TensorTypes to a regular class.  This required FlexibleContexts.
  (But we'll probably need it anyway when we support heterogeneous tensor
  lists.)
- Specializing NoneOf for long type lists.

For more details, see: https://ghc.haskell.org/trac/ghc/ticket/12175.

Also added 'directory' to tensorflow-core-ops' dependencies since it's used
in the Setup script.