### PR TITLE
Support type attributes that aren't used by an input/output.

### DIFF
--- a/tensorflow-core-ops/Setup.hs
+++ b/tensorflow-core-ops/Setup.hs
@@ -83,10 +83,6 @@ blackList =
     , "Print"
     , "QueueEnqueue"
     , "QueueEnqueueMany"
-      -- These have type ambiguities because one of the type arguments
-      -- doesn't appear in the signature.
-    , "ConditionalAccumulator"
-    , "SparseConditionalAccumulator"
       -- Need list of types support.
     , "DecodeCSV"
     , "ParseExample"


### PR DESCRIPTION
We should treat such attributes as regular `DataType` values rather than type
parameters; otherwise we'll get ambiguous types.  As with other attributes,
they can either set by default or passed in as an explicit argument to the op.

Allows us to reenable a couple more ops.