### PR TITLE
adds `initializedValue`

### DIFF
--- a/tensorflow-ops/src/TensorFlow/Ops.hs
+++ b/tensorflow-ops/src/TensorFlow/Ops.hs
@@ -68,6 +68,7 @@ module TensorFlow.Ops
     , constant
     , CoreOps.equal
     , expandDims
+    , initializedValue
     , initializedVariable
     , zeroInitializedVariable
     , CoreOps.fill
@@ -111,7 +112,9 @@ import Data.Int (Int32, Int64)
 import Prelude hiding (abs, sum, concat)
 import Data.ProtoLens (def)
 import Data.Text.Encoding (encodeUtf8)
+import Data.Set (fromList)
 import Lens.Family2 ((.~), (&))
+import Lens.Family2.State.Strict (use)
 import Text.Printf (printf)
 import Proto.Tensorflow.Core.Framework.Tensor
     ( TensorProto
@@ -160,6 +163,18 @@ placeholder shape' =
     buildOp $ opDef "Placeholder"
             & opAttr "dtype" .~ tensorType (undefined :: a)
             & opAttr "shape" .~ shape'
+
+
+-- | Construct a tensor whose value is the initialized value of the given
+-- tensor.
+initializedValue :: forall a.  TensorType a 
+    => Tensor Ref a 
+    -> Build (Tensor Ref a)
+initializedValue t = do
+    ns <- use initializationNodes
+    -- Make this tensor depend on the initializers of the other.
+    withNodeDependencies (fromList ns) (render t)
+
 
 -- | Creates a variable initialized to the given value.
 -- Initialization happens next time session runs.

--- a/tensorflow-ops/src/TensorFlow/Ops.hs
+++ b/tensorflow-ops/src/TensorFlow/Ops.hs
@@ -167,9 +167,9 @@ placeholder shape' =
 
 -- | Construct a tensor whose value is the initialized value of the given
 -- tensor.
-initializedValue :: forall a.  TensorType a 
-    => Tensor Ref a 
-    -> Build (Tensor Ref a)
+initializedValue :: forall a v.  TensorType a 
+    => Tensor v a 
+    -> Build (Tensor v a)
 initializedValue t = do
     ns <- use initializationNodes
     -- Make this tensor depend on the initializers of the other.

--- a/tensorflow-ops/tensorflow-ops.cabal
+++ b/tensorflow-ops/tensorflow-ops.cabal
@@ -42,6 +42,7 @@ Test-Suite BuildTest
                , google-shim
                , tensorflow
                , tensorflow-ops
+               , tensorflow-core-ops
                , tensorflow-proto
                , test-framework
                , test-framework-hunit

--- a/tensorflow-ops/tests/BuildTest.hs
+++ b/tensorflow-ops/tests/BuildTest.hs
@@ -43,10 +43,12 @@ import TensorFlow.Build
     )
 import TensorFlow.ControlFlow (named)
 import TensorFlow.Types (unScalar)
+import TensorFlow.GenOps.Core (identity)
 import TensorFlow.Ops
     ( add
     , assign
     , constant
+    , initializedValue
     , initializedVariable
     , variable
     )
@@ -109,7 +111,10 @@ testInitializedVariable =
 testInitializedVariableShape :: Test
 testInitializedVariableShape =
     testCase "testInitializedVariableShape" $ runSession $ do
-        vector <- build $ initializedVariable (constant [1] [42 :: Float])
+        vector <- build $ do
+                  a <- initializedVariable (constant [1] [42 :: Float])
+                  b <- initializedValue a
+                  return b
         result <- run vector
         liftIO $ [42] @=? (result :: V.Vector Float)
 

--- a/tensorflow-ops/tests/BuildTest.hs
+++ b/tensorflow-ops/tests/BuildTest.hs
@@ -113,7 +113,7 @@ testInitializedVariableShape =
     testCase "testInitializedVariableShape" $ runSession $ do
         vector <- build $ do
                   a <- initializedVariable (constant [1] [42 :: Float])
-                  b <- initializedValue a
+                  b <- initializedValue (identity a)
                   return b
         result <- run vector
         liftIO $ [42] @=? (result :: V.Vector Float)

--- a/tensorflow-ops/tests/BuildTest.hs
+++ b/tensorflow-ops/tests/BuildTest.hs
@@ -114,7 +114,8 @@ testInitializedVariableShape =
         vector <- build $ do
                   a <- initializedVariable (constant [1] [42 :: Float])
                   b <- initializedValue (identity a)
-                  return b
+                  c <- initializedVariable b
+                  return c
         result <- run vector
         liftIO $ [42] @=? (result :: V.Vector Float)
 

--- a/tensorflow/src/TensorFlow/Build.hs
+++ b/tensorflow/src/TensorFlow/Build.hs
@@ -59,6 +59,7 @@ module TensorFlow.Build
     , addSummary
     , SummaryTensor
     , collectAllSummaries
+    , initializationNodes
     ) where
 
 import Control.Monad.IO.Class (MonadIO(..))


### PR DESCRIPTION
as per https://github.com/blackgnezdo/tensorflow-haskell/commit/3f50193954f50dbbb3f773d8f719c887a66825a7 this attempts to introduce the `initialized_value` function.

do we want this? does this make sense?