### PR TITLE
Build and Install in Ubuntu 16.04 without Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,37 @@ There is also a demo application:
     cd tensorflow-mnist
     stack --docker --docker-image=$IMAGE_NAME build --exec Main
 
+## Build without Docker on Linux
+
+The following instructions were verified with Ubuntu 16.04 Xenial Xerus.
+It needs Python numpy and GHC and the user is prompted during the installation
+process.
+
+- Install the "protoc" binary somewhere in your PATH. You can get it by
+  downloading the corresponding file for your system from
+  https://github.com/google/protobuf/releases. (The corresponding file will be
+  named something like `protoc-*-.zip`.)
+  
+- Install dependencies
+
+    sudo apt-get install swig
+
+- Follow instructions in section "Using Bazel custom APT repository (recommended)"
+from [Bazel](https://bazel.build/versions/master/docs/install.html) to install Bazel
+
+
+- Build the TensorFlow library and install it on your machine:
+
+        cd third_party/tensorflow
+        ./configure  # Choose the defaults when prompted
+        bazel build -c opt tensorflow:libtensorflow_c.so
+        install bazel-bin/tensorflow/libtensorflow_c.so /usr/local/lib/libtensorflow_c.so
+
+- Update 'ldconfig'
+
+        Add /usr/local/lib/libtensorflow_c.so to /etc/ld.so.conf
+	Execute 'ldconfig' in the terminal
+
 ## Build on Mac OS X
 
 The following instructions were verified with Mac OS X El Capitan.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ from [Bazel](https://bazel.build/versions/master/docs/install.html) to install B
         Add /usr/local/lib/libtensorflow_c.so to /etc/ld.so.conf
 	Execute 'ldconfig' in the terminal
 
+- Run stack:
+
+        stack test
+
 ## Build on Mac OS X
 
 The following instructions were verified with Mac OS X El Capitan.


### PR DESCRIPTION
I have added the instructions that worked for me. 

The result is this.

       $ stack test   
tensorflow-0.1.0.0: test (suite: FFITest)
tensorflow-0.1.0.0: test (suite: VarIntTest)
tensorflow-core-ops-0.1.0.0: configure (lib)
tensorflow-core-ops-0.1.0.0: build (lib)
tensorflow-core-ops-0.1.0.0: copy/register
tensorflow-ops-0.1.0.0: configure (lib + test)
tensorflow-ops-0.1.0.0: build (lib + test)
tensorflow-ops-0.1.0.0: copy/register
tensorflow-mnist-0.1.0.0: configure (lib + exe + test)
tensorflow-mnist-0.1.0.0: build (lib + exe + test)
tensorflow-mnist-0.1.0.0: copy/register
tensorflow-mnist-0.1.0.0: test (suite: ParseTest)
tensorflow-nn-0.1.0.0: configure (lib + test)
tensorflow-nn-0.1.0.0: build (lib + test)
tensorflow-nn-0.1.0.0: copy/register
tensorflow-nn-0.1.0.0: test (suite: NNTest)
tensorflow-ops-0.1.0.0: test (suite: ArrayOpsTest)
tensorflow-ops-0.1.0.0: test (suite: BuildTest)
tensorflow-ops-0.1.0.0: test (suite: DataFlowOpsTest)
tensorflow-ops-0.1.0.0: test (suite: EmbeddingOpsTest)
tensorflow-ops-0.1.0.0: test (suite: GradientTest)
tensorflow-ops-0.1.0.0: test (suite: MiscTest)
tensorflow-ops-0.1.0.0: test (suite: OpsTest)
tensorflow-ops-0.1.0.0: test (suite: RegressionTest)
tensorflow-ops-0.1.0.0: test (suite: TracingTest)
tensorflow-ops-0.1.0.0: test (suite: TypesTest)
tensorflow-queue-0.1.0.0: configure (lib + test)
tensorflow-queue-0.1.0.0: build (lib + test)
tensorflow-queue-0.1.0.0: copy/register
tensorflow-queue-0.1.0.0: test (suite: QueueTest)
Log files have been written to: /home/mohan/Haskell/tensorflow-haskell/.stack-work/logs/
Completed 10 action(s).

