### PR TITLE
Support lists of tensors in ops.

### DIFF
--- a/tensorflow-core-ops/Setup.hs
+++ b/tensorflow-core-ops/Setup.hs
@@ -64,43 +64,9 @@ generatingOpsWrappers = hooks
                                       (prettyLazyText 80 $ docOpList flags x)
 
 blackList =
-    -- A few data flow ops take a list of heterogeneous
-    -- parameters which we don't support in general form.
-    [ "HashTable"
-    , "MutableDenseHashTable"
-    , "MutableHashTable"
-    , "MutableHashTableOfTensors"
-    , "QueueDequeue"
-    , "QueueDequeueMany"
-    , "QueueDequeueUpTo"
-    , "Stack"
-    , "TensorArray"
-    , "TensorArrayV2"
-    , "QueueEnqueueManyV2"
-    , "QueueDequeueV2"
-    , "QueueDequeueUpToV2"
-    , "QueueEnqueueV2"
-    , "QueueDequeueManyV2"
-    , "Stage"
-    , "Unstage"
-      -- These should be possible to support by adding a bunch of
-      -- overloads with a variable number of tuple arguments.
-    , "Assert"
-    , "BarrierTakeMany"
-    , "Print"
-    , "QueueEnqueue"
-    , "QueueEnqueueMany"
-      -- Need list of types support.
-    , "DecodeCSV"
-    , "ParseExample"
-    , "ParseSingleSequenceExample"
-    , "RestoreV2"
-    , "Save"
-    , "SaveV2"
-    , "SaveSlices"
-    , "SymbolicGradient"
-    , "_ArrayToList"
-    , "_ListToArray"
+    [ -- Requires the "func" type:
+      "SymbolicGradient"
       -- Easy: support larger result tuples.
+    , "ParseSingleSequenceExample"
     , "Skipgram"
     ]

--- a/tensorflow-opgen/src/TensorFlow/OpGen.hs
+++ b/tensorflow-opgen/src/TensorFlow/OpGen.hs
@@ -314,17 +314,18 @@ tensorArg p = case parsedArgCase p of
     ResourceArg -> "ResourceHandle"
     SimpleArg { argType = t, argCaseKind = k } -> tensorType t k
     ListArg { argType = t, argCaseKind = k } -> brackets $ tensorType t k
-    MixedListArg {argTypeAttr = t} -> "TensorList Value" <+> renderHaskellName t
+    MixedListArg {argTypeAttr = t, argCaseKind = k}
+        -> "TensorList" <+> kind k <+> renderHaskellName t
   where
+    kind k = case k of
+                ArgTensorRef -> "Ref"
+                ArgTensorValue -> "Value"
+                ArgTensorEither v' -> strictText v'
     tensorType t k = let
-        v = case k of
-                ArgTensorRef -> "Tensor Ref"
-                ArgTensorValue -> "Tensor Value"
-                ArgTensorEither v' -> "Tensor" <+> strictText v'
         a = case t of
                 ArgTypeFixed dt -> strictText $ dtTypeToHaskell dt
                 ArgTypeAttr n -> renderHaskellName n
-        in v <+> a
+        in "Tensor" <+> kind k <+> a
 
 attrComment :: Attr a -> Doc
 attrComment a = argComment' (attrName a) (attrDescription a)

--- a/tensorflow-opgen/src/TensorFlow/OpGen/ParsedOp.hs
+++ b/tensorflow-opgen/src/TensorFlow/OpGen/ParsedOp.hs
@@ -12,6 +12,7 @@ module TensorFlow.OpGen.ParsedOp
     , Attr(..)
     , AttrType(..)
     , AttrBaseType(..)
+    , TypeParam(..)
     , ParsedArg(..)
     , ParsedArgCase(..)
     , ArgType(..)
@@ -62,10 +63,8 @@ data ParsedOp = ParsedOp
     , explicitInputAttrs :: [Attr AttrType]
         -- ^ Attributes that must be set explicitly when creating the op.
         -- Associated with the type of the attribute.
-    , inferredTypeAttrs :: [Attr [DataType]]
+    , inferredTypeAttrs :: [Attr TypeParam]
         -- ^ Attributes that are type parameters.
-        -- Associated with the list of allowed types (see: TensorFlow.Types.OneOf).
-        -- If this list is empty, then any type is acceptable.
     , inferredListSizeAttrs :: [Attr (NonEmpty Name)]
         -- Attributes which are list sizes (ints) that are inferred automatically
         -- from one or more of the input tensors.
@@ -104,6 +103,13 @@ data AttrBaseType = AttrBytes | AttrInt64 | AttrFloat | AttrBool
                 | AttrType | AttrShape | AttrTensor
                 deriving Eq
 
+data TypeParam = TypeParam
+    { typeParamIsList :: Bool
+    , typeParamRestrictions :: Maybe [DataType]
+        -- ^ The list of allowed types (see: TensorFlow.Types.OneOf).
+        -- If 'Nothing', then any type is acceptable.
+    }
+
 -- | An input or output argument (Tensor) for an op.
 data ParsedArg = ParsedArg
     { parsedArgName :: Name
@@ -120,7 +126,6 @@ data ParsedArgCase
         }
     | MixedListArg { argTypeAttr :: Name, argCaseKind :: ArgKind }
         -- ^ A heterogeneous list.
-        -- TODO(judahjacobson): Implement this.
     | ResourceArg
 
 argKind :: ParsedArgCase -> Maybe ArgKind
@@ -223,11 +228,6 @@ parseOp o = ParsedOp
                 (o ^. inputArg) tensorKindParams
     tensorKindParams = ["v" <> Text.pack (show x) | x <- [1::Integer ..]]
     parsedOutputs = map (\a -> parseArg a (outputTensorKind a)) (o ^. outputArg)
-    -- Type attributes that can be inferred from at least one input or output.
-    argTypeAttrs = Set.fromList $ mapMaybe parsedArgTypeAttr
-                       $ parsedInputs ++ parsedOutputs
-    inferredTypeAttrs = filter ((`Set.member` argTypeAttrs) . tfName . attrName)
-                            $ mapMaybeAttrs getInferredTypeAttr $ o ^. attr
     -- Integer attributes that can be inferred from the size of at least one
     -- input list.
     inferredListSizeAttrs = mapMaybeAttrs (getInferredListSizeAttr parsedInputs)
@@ -235,10 +235,14 @@ parseOp o = ParsedOp
     implicitAttrs = Set.fromList $ map tfName $
                         map attrName inferredTypeAttrs
                             ++ map attrName inferredListSizeAttrs
-    -- Attributes that can't be inferred and don't have defaults, so must be passed
-    -- as separate arguments to the op.
+    inferredTypeAttrs = mapMaybeAttrs (getInferredTypeAttr argTypeParams) $ o ^. attr
+    argTypeParams = Set.fromList $ map tfName $
+                        mapMaybe (getArgTypeParam . parsedArgCase) $
+                            parsedInputs ++ parsedOutputs
+    -- Attributes that can't be inferred and don't have defaults, so must be
+    -- passed as separate arguments to the op.
     explicitInputAttrs = sortBy (comparing (tfName . attrName))
-                        $ mapMaybeAttrs (getExplicitInputAttr implicitAttrs)
+                        $ mapMaybeAttrs (getExplicitInputAttr o implicitAttrs)
                         $ o ^. attr
 
 -- TODO(judahjacobson): Some arguments should be refs.
@@ -252,29 +256,32 @@ outputTensorKind a
     | a ^. isRef = ArgTensorRef
     | otherwise = ArgTensorValue
 
-getExplicitInputAttr :: Set.Set TFName -> OpDef'AttrDef -> Maybe AttrType
-getExplicitInputAttr implicitAttrs a
+getExplicitInputAttr :: OpDef -> Set.Set TFName -> OpDef'AttrDef -> Maybe AttrType
+getExplicitInputAttr o implicitAttrs a
     | TFName (a ^. name) `Set.notMember` implicitAttrs
     , a ^. maybe'defaultValue == Nothing
-    , t <- parseAttrType (a ^. type')
-    , t `elem` map AttrSingle [AttrBool, AttrInt64, AttrFloat, AttrShape] = Just t
+    , t <- parseAttrType o (a ^. type')
+    , t `elem` map AttrSingle
+                    [AttrBool, AttrInt64, AttrFloat, AttrType, AttrShape]
+                ++ [AttrList AttrType] = Just t
     | otherwise = Nothing
 
--- | The type attribute used by this input or output (if any).
-parsedArgTypeAttr :: ParsedArg -> Maybe TFName
-parsedArgTypeAttr p = case parsedArgCase p of
-    ResourceArg -> Nothing
-    SimpleArg {argType = t} -> fromArgType t
-    ListArg {argType = t} -> fromArgType t
-    MixedListArg {argTypeAttr = n} -> Just $ tfName n
+getInferredTypeAttr :: Set.Set TFName -> OpDef'AttrDef -> Maybe TypeParam
+getInferredTypeAttr argTypeParams a
+    | TFName (a ^. name) `notElem` argTypeParams = Nothing
+    | a ^. type' == "type" = Just $ TypeParam False allowed
+    | a ^. type' == "list(type)" = Just $ TypeParam True allowed
+    | otherwise = Nothing
   where
-    fromArgType (ArgTypeAttr n) = Just $ tfName n
-    fromArgType _ = Nothing
+    allowed = case a ^. allowedValues . list . type' of
+                [] -> Nothing
+                as -> Just as
 
-getInferredTypeAttr :: OpDef'AttrDef -> Maybe [DataType]
-getInferredTypeAttr a
-    | a ^. type' == "type" = Just $ a ^. allowedValues . list . type'
-    | otherwise = Nothing
+getArgTypeParam :: ParsedArgCase -> Maybe Name
+getArgTypeParam SimpleArg { argType = ArgTypeAttr n} = Just n
+getArgTypeParam ListArg { argType = ArgTypeAttr n} = Just n
+getArgTypeParam MixedListArg { argTypeAttr = n } = Just n
+getArgTypeParam _ = Nothing
 
 getInferredListSizeAttr :: [ParsedArg] -> OpDef'AttrDef -> Maybe (NonEmpty Name)
 getInferredListSizeAttr inputs a
@@ -285,7 +292,7 @@ getInferredListSizeAttr inputs a
                                   } <- inputs
                       , TFName (a ^. name) == tfName n]
     | otherwise = Nothing
-    
+
 -- | Like mapMaybe, but associates the attribute name/description with the given info.
 mapMaybeAttrs :: (OpDef'AttrDef -> Maybe a) -> [OpDef'AttrDef] -> [Attr a]
 mapMaybeAttrs f = mapMaybe $ \a -> do
@@ -295,7 +302,7 @@ mapMaybeAttrs f = mapMaybe $ \a -> do
                                 , attrDescription = a ^. description
                                 , attrInfo = x
                                 }
-  
+
 parseArg :: OpDef'ArgDef -> ArgKind -> ParsedArg
 parseArg a tKind = ParsedArg
     { parsedArgName = makeName (a ^. name)
@@ -317,15 +324,15 @@ parseArgCase a tKind
     maybeAttr "" = Nothing
     maybeAttr t = Just $ makeName t
 
-parseAttrType :: Text -> AttrType
-parseAttrType = \case
+parseAttrType :: OpDef -> Text -> AttrType
+parseAttrType o = \case
     "string" -> AttrSingle AttrBytes
-    "int" -> AttrSingle AttrInt64 
-    "float" -> AttrSingle AttrFloat 
-    "bool" -> AttrSingle AttrBool 
-    "type" -> AttrSingle AttrType 
-    "shape" -> AttrSingle AttrShape 
-    "tensor" -> AttrSingle AttrTensor 
+    "int" -> AttrSingle AttrInt64
+    "float" -> AttrSingle AttrFloat
+    "bool" -> AttrSingle AttrBool
+    "type" -> AttrSingle AttrType
+    "shape" -> AttrSingle AttrShape
+    "tensor" -> AttrSingle AttrTensor
     "list(string)" -> AttrList AttrBytes
     "list(int)" -> AttrList AttrInt64
     "list(float)" -> AttrList AttrFloat
@@ -334,3 +341,4 @@ parseAttrType = \case
     "list(shape)" -> AttrList AttrShape
     "list(tensor)" -> AttrList AttrTensor
     t -> error $ "parseAttrType: unrecognized type " ++ show t
+              ++ " for op " ++ show (o ^. name)

--- a/tensorflow-opgen/src/TensorFlow/OpGen/ParsedOp.hs
+++ b/tensorflow-opgen/src/TensorFlow/OpGen/ParsedOp.hs
@@ -105,7 +105,7 @@ data AttrBaseType = AttrBytes | AttrInt64 | AttrFloat | AttrBool
 
 data TypeParam = TypeParam
     { typeParamIsList :: Bool
-    , typeParamRestrictions :: Maybe [DataType]
+    , typeParamRestrictions :: Maybe (NonEmpty DataType)
         -- ^ The list of allowed types (see: TensorFlow.Types.OneOf).
         -- If 'Nothing', then any type is acceptable.
     }
@@ -273,9 +273,7 @@ getInferredTypeAttr argTypeParams a
     | a ^. type' == "list(type)" = Just $ TypeParam True allowed
     | otherwise = Nothing
   where
-    allowed = case a ^. allowedValues . list . type' of
-                [] -> Nothing
-                as -> Just as
+    allowed = nonEmpty (a ^. allowedValues . list . type')
 
 getArgTypeParam :: ParsedArgCase -> Maybe Name
 getArgTypeParam SimpleArg { argType = ArgTypeAttr n} = Just n

--- a/tensorflow-queue/src/TensorFlow/Queue.hs
+++ b/tensorflow-queue/src/TensorFlow/Queue.hs
@@ -28,7 +28,7 @@ import TensorFlow.Build (ControlNode, Build, addInitializer, opAttr, opDef)
 import TensorFlow.BuildOp (buildOp)
 import TensorFlow.ControlFlow (group)
 import TensorFlow.Tensor (Ref, Tensor, TensorList)
-import TensorFlow.Types (TensorType, tensorType, TensorTypes, fromTensorTypes)
+import TensorFlow.Types (TensorTypes, fromTensorTypes)
 
 -- | A queue carrying tuples.
 data Queue (as :: [*]) = Queue { handle :: Handle }

--- a/tensorflow-queue/src/TensorFlow/Queue.hs
+++ b/tensorflow-queue/src/TensorFlow/Queue.hs
@@ -49,7 +49,7 @@ enqueue q =
 dequeue :: forall as . TensorTypes as
            => Queue as
            -> Build (TensorList Ref as)
-           -- ^ Dequeued tensors. They are paired in a sense
+           -- ^ Dequeued tensors. They are coupled in a sense
            -- that values appear together, even if they are
            -- not consumed together.
 dequeue q =

--- a/tensorflow-queue/tests/QueueTest.hs
+++ b/tensorflow-queue/tests/QueueTest.hs
@@ -21,7 +21,7 @@ module Main where
 import Control.Monad.IO.Class (liftIO)
 import Data.Int (Int64)
 import Google.Test (googleTest)
-import TensorFlow.Types (ListOf(..), Scalar(..), (|:|))
+import TensorFlow.Types (ListOf(..), Scalar(..), (/:/))
 import TensorFlow.Ops (scalar)
 import TensorFlow.Queue
 import TensorFlow.Session
@@ -41,18 +41,18 @@ import qualified Data.ByteString as BS
 testBasic :: Test
 testBasic = testCase "testBasic" $ runSession $ do
     q :: Queue [Int64, BS.ByteString] <- build $ makeQueue 1 ""
-    buildAnd run_ $ enqueue q $ 42 :| scalar "Hi" :| Nil
+    buildAnd run_ $ enqueue q $ 42 :/ scalar "Hi" :/ Nil
     x <- buildAnd run (dequeue q)
-    liftIO $ (Scalar 42 |:| Scalar "Hi" |:| Nil) @=? x
+    liftIO $ (Scalar 42 /:/ Scalar "Hi" /:/ Nil) @=? x
 
-    buildAnd run_ $ enqueue q $ 56 :| scalar "Bar" :| Nil
+    buildAnd run_ $ enqueue q $ 56 :/ scalar "Bar" :/ Nil
     y <- buildAnd run (dequeue q)
     -- Note: we use explicit "Scalar" here to specify the type that was
     -- fetched.  Equivalently we could write
-    -- 56 |:| "Bar" |:| Nil :: List [Scalar Int64, Scalar BS.ByteString]
+    -- 56 /:/ "Bar" /:/ Nil :: List [Scalar Int64, Scalar BS.ByteString]
     -- or else allow the types to be determined by future use of the fetched
     -- value.
-    let expected = Scalar 56 |:| Scalar "Bar" |:| Nil
+    let expected = Scalar 56 /:/ Scalar "Bar" /:/ Nil
     liftIO $ expected @=? y
 
 -- | Test queue pumping.
@@ -61,14 +61,14 @@ testPump = testCase "testPump" $ runSession $ do
     (deq, pump) <- build $ do
         q :: Queue [Int64, BS.ByteString] <- makeQueue 2 "ThePumpQueue"
         (,) <$> dequeue q
-            <*> enqueue q (31 :| scalar "Baz" :| Nil)
+            <*> enqueue q (31 :/ scalar "Baz" :/ Nil)
     -- This is a realistic use. The pump inputs are pre-bound to some
     -- nodes that produce values when pumped (e.g. read from a
     -- file).
     run_ (pump, pump)
 
     (x, y) <- run (deq, deq)
-    let expected = Scalar 31 |:| Scalar "Baz" |:| Nil
+    let expected = Scalar 31 /:/ Scalar "Baz" /:/ Nil
     liftIO $ expected @=? x
     liftIO $ expected @=? y
 
@@ -77,11 +77,11 @@ testAsync = testCase "testAsync" $ runSession $ do
     (deq, pump) <- build $ do
         q :: Queue [Int64, BS.ByteString] <- makeQueue 2 ""
         (,) <$> dequeue q
-            <*> enqueue q (10 :| scalar "Async" :| Nil)
+            <*> enqueue q (10 :/ scalar "Async" :/ Nil)
     -- Pumps the queue until canceled by runSession exiting.
     asyncProdNodes pump
     -- Picks up a couple values and verifies they are as expected.
-    let expected = Scalar 10 |:| Scalar "Async" |:| Nil
+    let expected = Scalar 10 /:/ Scalar "Async" /:/ Nil
     run deq >>= liftIO . (expected @=?)
     run deq >>= liftIO . (expected @=?)
 

--- a/tensorflow/src/TensorFlow/BuildOp.hs
+++ b/tensorflow/src/TensorFlow/BuildOp.hs
@@ -13,6 +13,8 @@
 -- limitations under the License.
 
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 
 module TensorFlow.BuildOp
@@ -28,11 +30,13 @@ import Control.Monad (replicateM)
 import Control.Monad.Reader (ReaderT, runReaderT, ask)
 import Control.Monad.State.Strict (State, runState, get, put)
 import Data.Int (Int64)
+import Data.Proxy (Proxy(..))
 import Lens.Family2 ((&), (<>~), (^.))
 
 import TensorFlow.Build
 import TensorFlow.Output
 import TensorFlow.Tensor
+import TensorFlow.Types
 
 data ResultState = ResultState !OutputIx [Int64] deriving Show
 
@@ -98,6 +102,22 @@ instance OpResult (Tensor Ref a) where
 instance OpResult ControlNode where
     toResult = ControlNode <$> ask
 
+tensorListResult :: forall as v . TensorTypes as => TensorKind v -> Result (TensorList v as)
+tensorListResult v = loop (tensorTypes :: TensorTypeList as)
+  where
+    loop :: TensorTypeList bs -> Result (TensorList v bs)
+    loop Nil = return Nil
+    loop (TensorTypeProxy :| ls) = do
+        t <- tensorResult v
+        ts <- loop ls
+        return (t :| ts)
+
+instance TensorTypes as => OpResult (TensorList Value as) where
+    toResult = tensorListResult ValueKind
+
+instance TensorTypes as => OpResult (TensorList Ref as) where
+    toResult = tensorListResult RefKind
+
 instance OpResult a => OpResult [a] where
     toResult = do
         ResultState i ns <- get
@@ -159,6 +179,12 @@ instance BuildOp (Tensor Value a) where
 instance BuildOp (Tensor Ref a) where
     buildOp' = pureResult
 
+instance TensorTypes as => BuildOp (TensorList Value as) where
+    buildOp' = pureResult
+
+instance TensorTypes as => BuildOp (TensorList Ref as) where
+    buildOp' = pureResult
+
 instance BuildOp [Tensor Value a] where
     buildOp' = pureResult
 
@@ -198,6 +224,10 @@ instance BuildOp f => BuildOp (Tensor v a -> f) where
 instance BuildOp f => BuildOp ([Tensor v a] -> f) where
     buildOp' rf o accum ts
         = buildOp' rf o (reverse (fmap (^. tensorOutput) ts) ++ accum)
+
+instance BuildOp f => BuildOp (TensorList v as -> f) where
+    buildOp' rf o accum ts
+        = buildOp' rf o (reverse (tensorListOutputs ts) ++ accum)
 
 -- | Returns true if all the integers in each tuple are identical.
 -- Throws an error with a descriptive message if not.

--- a/tensorflow/src/TensorFlow/BuildOp.hs
+++ b/tensorflow/src/TensorFlow/BuildOp.hs
@@ -106,10 +106,10 @@ tensorListResult v = loop (tensorTypes :: TensorTypeList as)
   where
     loop :: TensorTypeList bs -> Result (TensorList v bs)
     loop Nil = return Nil
-    loop (TensorTypeProxy :| ls) = do
+    loop (TensorTypeProxy :/ ls) = do
         t <- tensorResult v
         ts <- loop ls
-        return (t :| ts)
+        return (t :/ ts)
 
 instance TensorTypes as => OpResult (TensorList Value as) where
     toResult = tensorListResult ValueKind

--- a/tensorflow/src/TensorFlow/BuildOp.hs
+++ b/tensorflow/src/TensorFlow/BuildOp.hs
@@ -30,7 +30,6 @@ import Control.Monad (replicateM)
 import Control.Monad.Reader (ReaderT, runReaderT, ask)
 import Control.Monad.State.Strict (State, runState, get, put)
 import Data.Int (Int64)
-import Data.Proxy (Proxy(..))
 import Lens.Family2 ((&), (<>~), (^.))
 
 import TensorFlow.Build

--- a/tensorflow/src/TensorFlow/Nodes.hs
+++ b/tensorflow/src/TensorFlow/Nodes.hs
@@ -23,7 +23,7 @@
 module TensorFlow.Nodes where
 
 import Control.Applicative (liftA2, liftA3)
-import Data.Functor.Identity (Identity(..))
+import Data.Functor.Identity (Identity)
 import Data.Map.Strict (Map)
 import Data.Monoid ((<>))
 import Data.Set (Set)
@@ -99,8 +99,6 @@ instance Nodes ControlNode where
 instance a ~ () => Fetchable ControlNode a where
     getFetch _ = return $ pure ()
 
--- hm, annoying but doable.
--- unfortunately, pulling out requires a "Identity" everywhere...bleh
 instance Nodes (ListOf f '[]) where
     getNodes _ = return Set.empty
 
@@ -112,7 +110,7 @@ instance l ~ List '[] => Fetchable (ListOf f '[]) l where
 
 instance (Fetchable (f t) a, Fetchable (ListOf f ts) (List as), i ~ Identity)
     => Fetchable (ListOf f (t ': ts)) (ListOf i (a ': as)) where
-    getFetch (x :| xs) = liftA2 (\y ys -> Identity y :| ys) <$> getFetch x <*> getFetch xs
+    getFetch (x :| xs) = liftA2 (\y ys -> y |:| ys) <$> getFetch x <*> getFetch xs
 
 instance Nodes (Tensor v a) where
     getNodes t = Set.singleton <$> getOrAddOp (t ^. tensorOutput . outputOp)

--- a/tensorflow/src/TensorFlow/Nodes.hs
+++ b/tensorflow/src/TensorFlow/Nodes.hs
@@ -103,14 +103,14 @@ instance Nodes (ListOf f '[]) where
     getNodes _ = return Set.empty
 
 instance (Nodes (f a), Nodes (ListOf f as)) => Nodes (ListOf f (a ': as)) where
-    getNodes (x :| xs) = liftA2 Set.union (getNodes x) (getNodes xs)
+    getNodes (x :/ xs) = liftA2 Set.union (getNodes x) (getNodes xs)
 
 instance l ~ List '[] => Fetchable (ListOf f '[]) l where
     getFetch _ = return $ pure Nil
 
 instance (Fetchable (f t) a, Fetchable (ListOf f ts) (List as), i ~ Identity)
     => Fetchable (ListOf f (t ': ts)) (ListOf i (a ': as)) where
-    getFetch (x :| xs) = liftA2 (\y ys -> y |:| ys) <$> getFetch x <*> getFetch xs
+    getFetch (x :/ xs) = liftA2 (\y ys -> y /:/ ys) <$> getFetch x <*> getFetch xs
 
 instance Nodes (Tensor v a) where
     getNodes t = Set.singleton <$> getOrAddOp (t ^. tensorOutput . outputOp)

--- a/tensorflow/src/TensorFlow/Tensor.hs
+++ b/tensorflow/src/TensorFlow/Tensor.hs
@@ -12,20 +12,31 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module TensorFlow.Tensor where
 
 import Data.String (IsString(..))
 import qualified Data.Text as Text
-import Lens.Family2 (Lens', Traversal')
+import Lens.Family2 (Lens', Traversal', (^.))
 import Lens.Family2.Unchecked (lens)
 
 import TensorFlow.Output (Output, outputOp, opUnrendered, opAttr)
-import TensorFlow.Types (TensorData(..), Attribute)
+import TensorFlow.Types
+    ( TensorData(..)
+    , Attribute
+    , ListOf(..)
+    )
 import qualified TensorFlow.Internal.FFI as FFI
 
 -- | A named output of a TensorFlow operation.
@@ -83,3 +94,9 @@ feed (Tensor _ o) (TensorData td) = Feed o td
 -- TODO(judahjacobson): add more safety checks here.
 tensorFromName :: TensorKind v -> Text.Text -> Tensor v a
 tensorFromName v = Tensor v . fromString . Text.unpack
+
+type TensorList v = ListOf (Tensor v)
+
+tensorListOutputs :: TensorList v as -> [Output]
+tensorListOutputs Nil = []
+tensorListOutputs (t :| ts) = (t ^. tensorOutput) : tensorListOutputs ts

--- a/tensorflow/src/TensorFlow/Tensor.hs
+++ b/tensorflow/src/TensorFlow/Tensor.hs
@@ -98,4 +98,4 @@ type TensorList v = ListOf (Tensor v)
 
 tensorListOutputs :: TensorList v as -> [Output]
 tensorListOutputs Nil = []
-tensorListOutputs (t :| ts) = (t ^. tensorOutput) : tensorListOutputs ts
+tensorListOutputs (t :/ ts) = (t ^. tensorOutput) : tensorListOutputs ts

--- a/tensorflow/src/TensorFlow/Tensor.hs
+++ b/tensorflow/src/TensorFlow/Tensor.hs
@@ -22,7 +22,6 @@
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 module TensorFlow.Tensor where
 

--- a/tensorflow/src/TensorFlow/Types.hs
+++ b/tensorflow/src/TensorFlow/Types.hs
@@ -42,6 +42,7 @@ module TensorFlow.Types
     -- * Lists
     , ListOf(..)
     , List
+    , (|:|)
     , TensorTypeProxy(..)
     , TensorTypes(..)
     , TensorTypeList
@@ -60,7 +61,7 @@ module TensorFlow.Types
     , AllTensorTypes
     ) where
 
-import Data.Functor.Identity (Identity)
+import Data.Functor.Identity (Identity(..))
 import Data.Complex (Complex)
 import Data.Default (def)
 import Data.Int (Int8, Int16, Int32, Int64)
@@ -420,6 +421,12 @@ instance All Show (Map f as) => Show (ListOf f as) where
                                     . showsPrec 6 xs
 
 type List = ListOf Identity
+
+-- | Equivalent of ':|' for lists.
+(|:|) :: a -> List as -> List (a ': as)
+(|:|) = (:|) . Identity
+
+infixr 5 |:|
 
 -- | A 'Constraint' specifying the possible choices of a 'TensorType'.
 --

--- a/tensorflow/src/TensorFlow/Types.hs
+++ b/tensorflow/src/TensorFlow/Types.hs
@@ -13,6 +13,7 @@
 -- limitations under the License.
 
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -406,6 +407,11 @@ type family Map f as where
 instance All Eq (Map f as) => Eq (ListOf f as) where
     Nil == Nil = True
     (x :| xs) == (y :| ys) = x == y && xs == ys
+    -- Newer versions of GHC use the GADT to tell that the previous cases are
+    -- exhaustive.
+#if _GLASGOW_HASKELL__ < 800
+    _ == _ = False
+#endif
 
 instance All Show (Map f as) => Show (ListOf f as) where
     showsPrec _ Nil = showString "Nil"


### PR DESCRIPTION
Adds a new type `ListOf` which wraps a heterogeneous list; for example,
`ListOf (Tensor Value) '[Int32, Float]` represents a list of two
elements: a tensor of int32s and a tensor of floats.

Also changes the `Queue2` type (which suppored pairs of tensors) to
`Queue` (which supports arbitrary lists).