### PR TITLE
Add versions of each op that take optional params as an extra arg.

### DIFF
--- a/tensorflow-ops/src/TensorFlow/Gradient.hs
+++ b/tensorflow-ops/src/TensorFlow/Gradient.hs
@@ -72,6 +72,7 @@ import TensorFlow.Ops
     , expandDims
     , fill
     , matMul
+    , matMul'
     , reducedShape
     , reluGrad
     , reshape
@@ -95,7 +96,6 @@ import TensorFlow.Tensor
     , TensorKind (ValueKind)
     , Value
     , tensorOutput
-    , tensorAttr
     )
 import TensorFlow.Types (Attribute, OneOf, TensorType, attrLens)
 import Proto.Tensorflow.Core.Framework.NodeDef
@@ -532,20 +532,20 @@ opGrad "MatMul" nodeDef [toT -> x, toT -> y] [dz] =
     let transposeA = lookupAttr nodeDef "transpose_a"
         transposeB = lookupAttr nodeDef "transpose_b"
         transAttrs a b =
-            (tensorAttr "transpose_a" .~ a) . (tensorAttr "transpose_b" .~ b)
+            (opAttr "transpose_a" .~ a) . (opAttr "transpose_b" .~ b)
     in case (transposeA, transposeB) of
        (False, False) ->
-           [ Just $ (dz `matMul` y) & transAttrs False True
-           , Just $ (x `matMul` dz) & transAttrs True False ]
+           [ Just $ matMul' (transAttrs False True) dz y
+           , Just $ matMul' (transAttrs True False) x dz]
        (False, True) ->
-           [ Just $ dz `matMul` y
-           , Just $ (x `matMul` dz) & transAttrs True False ]
+           [ Just $ matMul dz y
+           , Just $ matMul' (transAttrs True False) x dz]
        (True, False) ->
-           [ Just $ (dz `matMul` y) & transAttrs False True
-           , Just $ x `matMul` dz ]
+           [ Just $ matMul' (transAttrs False True) dz y
+           , Just $ matMul x dz]
        (True, True) ->
-           [ Just $ (dz `matMul` y) & transAttrs True True
-           , Just $ (x `matMul` dz) & transAttrs True True ]
+           [ Just $ matMul' (transAttrs True True) dz y
+           , Just $ matMul' (transAttrs True True) x dz]
 
 opGrad "Transpose" _ [_, toT -> p] [dz] =
     [ Just $ CoreOps.transpose dz
@@ -554,16 +554,18 @@ opGrad "Transpose" _ [_, toT -> p] [dz] =
     ]
 
 opGrad "Conv2D" nodeDef [toT -> x, toT -> y] [dz] =
-    [ Just $ CoreOps.conv2DBackpropInput (shape x) y dz
-          & tensorAttr "strides" .~ strides
-          & tensorAttr "padding" .~ padding
-          & tensorAttr "use_cudnn_on_gpu" .~ useCudnnOnGpu
-          & tensorAttr "data_format" .~ dataFormat
-    , Just $ CoreOps.conv2DBackpropFilter x (shape y) dz
-          & tensorAttr "strides" .~ strides
-          & tensorAttr "padding" .~ padding
-          & tensorAttr "use_cudnn_on_gpu" .~ useCudnnOnGpu
-          & tensorAttr "data_format" .~ dataFormat
+    [ Just $ CoreOps.conv2DBackpropInput'
+                ((opAttr "strides" .~ strides)
+                    . (opAttr "padding" .~ padding)
+                    . (opAttr "use_cudnn_on_gpu" .~ useCudnnOnGpu)
+                    . (opAttr "data_format" .~ dataFormat))
+                (shape x) y dz
+    , Just $ CoreOps.conv2DBackpropFilter'
+                ((opAttr "strides" .~ strides)
+                    . (opAttr "padding" .~ padding)
+                    . (opAttr "use_cudnn_on_gpu" .~ useCudnnOnGpu)
+                    . (opAttr "data_format" .~ dataFormat))
+                x (shape y) dz
     ]
   where
     strides = lookupAttr nodeDef "strides" :: [Int64]
@@ -572,11 +574,12 @@ opGrad "Conv2D" nodeDef [toT -> x, toT -> y] [dz] =
     dataFormat = lookupAttr nodeDef "data_format" :: ByteString
 
 opGrad "MaxPool" nodeDef [toT -> x] [dz] =
-    [ Just $ CoreOps.maxPoolGrad x output dz
-          & tensorAttr "ksize" .~ ksize
-          & tensorAttr "strides" .~ strides
-          & tensorAttr "padding" .~ padding
-          & tensorAttr "data_format" .~ dataFormat
+    [ Just $ CoreOps.maxPoolGrad'
+                ((opAttr "ksize" .~ ksize)
+                    . (opAttr "strides" .~ strides)
+                    . (opAttr "padding" .~ padding)
+                    . (opAttr "data_format" .~ dataFormat))
+                x output dz
     ]
   where
     output :: Tensor Value a

--- a/tensorflow-ops/tests/OpsTest.hs
+++ b/tensorflow-ops/tests/OpsTest.hs
@@ -19,6 +19,7 @@ module Main where
 import Control.Monad.IO.Class (liftIO)
 import Data.Int (Int32, Int64)
 import Google.Test (googleTest)
+import Lens.Family2 ((.~))
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Framework (Test)
 import Test.Framework.Providers.HUnit (testCase)
@@ -27,7 +28,6 @@ import qualified Data.ByteString.Char8 as B8
 
 import qualified Data.Vector as V
 import qualified TensorFlow.Build as TF
-import qualified TensorFlow.ControlFlow as TF
 import qualified TensorFlow.Nodes as TF
 import qualified TensorFlow.Ops as TF
 import qualified TensorFlow.Session as TF
@@ -56,7 +56,8 @@ testSaveRestore = testCase "testSaveRestore" $
         let path = B8.pack $ dirPath ++ "/checkpoint"
             var :: TF.MonadBuild m => m (TF.Tensor TF.Ref Float)
             var = TF.render =<<
-                  TF.named "a" <$> TF.zeroInitializedVariable (TF.Shape [])
+                  TF.zeroInitializedVariable' (TF.opName .~ "a")
+                                        (TF.Shape [])
         TF.runSession $ do
             v <- var
             TF.assign v 134 >>= TF.run_

--- a/tensorflow-ops/tests/TypesTest.hs
+++ b/tensorflow-ops/tests/TypesTest.hs
@@ -36,7 +36,6 @@ import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Vector as V
 
-import qualified TensorFlow.ControlFlow as TF
 import qualified TensorFlow.GenOps.Core as TF (select)
 import qualified TensorFlow.Ops as TF
 import qualified TensorFlow.Session as TF

--- a/tensorflow/src/TensorFlow/BuildOp.hs
+++ b/tensorflow/src/TensorFlow/BuildOp.hs
@@ -23,6 +23,7 @@ module TensorFlow.BuildOp
     , buildOp
     , buildListOp
     , eqLengthGuard
+    , OpParams
     )
   where
 
@@ -238,3 +239,7 @@ eqLengthGuard = all eachOk
     eachOk (numberAttrName, pairs@((_, x) : zs)) = all (\z -> snd z == x) zs ||
         error ("number_attr " ++ numberAttrName ++
                " contains tensors with different length " ++ show pairs)
+
+-- | Parameters to build an op (for example, the node name or optional attributes).
+-- TODO: be more type safe.
+type OpParams = OpDef -> OpDef

--- a/tensorflow/src/TensorFlow/Core.hs
+++ b/tensorflow/src/TensorFlow/Core.hs
@@ -50,14 +50,14 @@ module TensorFlow.Core
     , render
     , asGraphDef
     , addGraphDef
-
+    , opName
+    , opAttr
       -- * Tensor
     , ControlNode
     , Tensor
     , Value
     , Ref
     , TensorKind(..)
-    , tensorAttr
     , value
     , tensorFromName
       -- ** Element types
@@ -74,12 +74,10 @@ module TensorFlow.Core
     , Device(..)
     , withDevice
     , withNameScope
-    , named
       -- ** Dependencies
     , withControlDependencies
     , group
       -- ** Misc
-    , identity
     , noOp
     ) where
 

--- a/tensorflow/src/TensorFlow/Output.hs
+++ b/tensorflow/src/TensorFlow/Output.hs
@@ -124,6 +124,9 @@ data OpDef = OpDef
 data PendingNodeName = ExplicitName !Text | ImplicitName
     deriving (Eq, Ord, Show)
 
+instance IsString PendingNodeName where
+    fromString = ExplicitName . fromString
+
 -- | The name of a node in the graph.  This corresponds to the proto field
 -- NodeDef.name.  Includes the scope prefix (if any) and a unique identifier
 -- (if the node was implicitly named).

--- a/tensorflow/src/TensorFlow/Tensor.hs
+++ b/tensorflow/src/TensorFlow/Tensor.hs
@@ -27,13 +27,12 @@ module TensorFlow.Tensor where
 
 import Data.String (IsString(..))
 import qualified Data.Text as Text
-import Lens.Family2 (Lens', Traversal', (^.))
+import Lens.Family2 (Lens', (^.))
 import Lens.Family2.Unchecked (lens)
 
-import TensorFlow.Output (Output, outputOp, opUnrendered, opAttr)
+import TensorFlow.Output (Output)
 import TensorFlow.Types
     ( TensorData(..)
-    , Attribute
     , ListOf(..)
     )
 import qualified TensorFlow.Internal.FFI as FFI
@@ -61,15 +60,6 @@ tensorKind = lens (\(Tensor v _) -> v) (\(Tensor _ o) v -> Tensor v o)
 
 tensorOutput :: Lens' (Tensor v a) Output
 tensorOutput = lens (\(Tensor _ o) -> o) (\(Tensor v _) o -> Tensor v o)
-
--- TODO: Come up with a better API for handling attributes.
--- | Lens for the attributes of a tensor.
---
--- Only valid if the tensor has not yet been rendered. If the tensor has been
--- rendered, the traversal will be over nothing (nothing can be read or
--- written).
-tensorAttr :: Attribute attr => Text.Text -> Traversal' (Tensor v a) attr
-tensorAttr x = tensorOutput . outputOp . opUnrendered . opAttr x
 
 -- | Cast a 'Tensor *' into a 'Tensor Value'. Common usage is to cast a
 -- Ref into Value. This behaves like a no-op.


### PR DESCRIPTION
Each op `foo :: ...` now has a corresponding `foo' :: OpParams -> ...`
which lets you set optional attributes.  `OpParams` is currently a type alias for
`OpDef -> OpDef`.  In the future we should consider more type safety, e.g.,
using type-level strings and OverloadedLabels for optional attributes.

I used it to replace a few manual `buildOp`s in our code with the codegenerated
ops, now that it's easier to set attributes.  I also removed `tensorAttr` and
`named` since it's now possible to set those op attributes directly.

Although this clutters up the API a bit, I think it's simpler than using type
classes to implement optional arguments (as in, for example, `Text.Printf`) --
especially in terms of type inference with the rest of the library.