### PR TITLE
Implemented gradient of ReluGrad and Fill

### DIFF
--- a/tensorflow-ops/tests/GradientTest.hs
+++ b/tensorflow-ops/tests/GradientTest.hs
@@ -160,6 +160,33 @@ testMaxGradient = testCase "testMaxGradient" $ do
     V.fromList [0, 0, 1, 0, 0 :: Float] @=? dx
 
 
+testReluGrad :: Test
+testReluGrad = testCase "testReluGrad" $ do
+    [dx] <- TF.runSession $ do
+        x <- TF.render $ TF.vector [2 :: Float]
+        let y = TF.relu x
+        TF.gradients y [x] >>= TF.run
+    V.fromList [1] @=? dx
+
+testReluGradGrad :: Test
+testReluGradGrad = testCase "testReluGradGrad" $ do
+    [dx] <- TF.runSession $ do
+        x <- TF.render $ TF.vector [2 :: Float]
+        let y = TF.relu x
+        [y'] <- TF.gradients y [x]
+        TF.gradients y' [x] >>= TF.run
+    V.fromList [0] @=? dx
+
+
+testFillGrad :: Test
+testFillGrad = testCase "testFillGrad" $ do
+    [dx] <- TF.runSession $ do
+        x <- TF.render $ TF.scalar (9 :: Float)
+        let shape = TF.vector [2, 3 :: Int32]
+        let y = TF.fill shape x
+        TF.gradients y [x] >>= TF.run
+    V.fromList [6] @=? dx
+
 main :: IO ()
 main = googleTest [ testGradientSimple
                   , testGradientDisconnected
@@ -167,4 +194,7 @@ main = googleTest [ testGradientSimple
                   , testCreateGraphNameScopes
                   , testDiamond
                   , testMaxGradient
+                  , testReluGrad
+                  , testReluGradGrad
+                  , testFillGrad
                   ]


### PR DESCRIPTION
Implementation of "ReluGradGrad", emulating the python implementation. Implementing gradient of "Fill" was also necessary to get the tests to run. Added two testcases, one for ReluGrad and one for ReluGradGrad.

I am unsure if implementations are correct when it comes to higher dimensionalities etc. Particularly the use of 'sum" in the "Fill" gradient as the python implementation uses math_ops.reduce_sum(grad).