### PR TITLE
Fix for gradients of matMul with transposed inputs.

### DIFF
--- a/tensorflow-ops/src/TensorFlow/Gradient.hs
+++ b/tensorflow-ops/src/TensorFlow/Gradient.hs
@@ -551,13 +551,13 @@ opGrad "MatMul" nodeDef [toT -> x, toT -> y] [dz] =
            , Just $ matMul' (transAttrs True False) x dz]
        (False, True) ->
            [ Just $ matMul dz y
-           , Just $ matMul' (transAttrs True False) x dz]
+           , Just $ matMul' (transAttrs True False) dz x]
        (True, False) ->
-           [ Just $ matMul' (transAttrs False True) dz y
+           [ Just $ matMul' (transAttrs False True) y dz
            , Just $ matMul x dz]
        (True, True) ->
-           [ Just $ matMul' (transAttrs True True) dz y
-           , Just $ matMul' (transAttrs True True) x dz]
+           [ Just $ matMul' (transAttrs True True) y dz
+           , Just $ matMul' (transAttrs True True) dz x]
 
 opGrad "Transpose" _ [_, toT -> p] [dz] =
     [ Just $ CoreOps.transpose dz

--- a/tensorflow-ops/src/TensorFlow/Ops.hs
+++ b/tensorflow-ops/src/TensorFlow/Ops.hs
@@ -345,7 +345,7 @@ scalar' :: TensorType a => OpParams -> a -> Tensor Build a
 scalar' params x = constant' params [] [x]
 
 -- | Random tensor from the unit normal distribution with bounded values.
--- 
+--
 -- This is a type-restricted version of 'TensorFlow.GenOps.Core.truncatedNormal'.
 truncatedNormal :: (MonadBuild m, OneOf '[Word16, Double, Float] a)
                 => Tensor v Int64  -- ^ Shape.

--- a/tensorflow-ops/src/TensorFlow/Ops.hs
+++ b/tensorflow-ops/src/TensorFlow/Ops.hs
@@ -133,6 +133,8 @@ module TensorFlow.Ops
     , CoreOps.sub'
     , CoreOps.sum
     , CoreOps.sum'
+    , reduceSum
+    , reduceSum'
     , CoreOps.transpose
     , CoreOps.transpose'
     , truncatedNormal
@@ -314,6 +316,25 @@ scalarize t = CoreOps.reshape t (vector scalarShape)
     where
         scalarShape = [] :: [Int32]
 
+-- | Sum a tensor down to a scalar
+-- Seee `TensorFlow.GenOps.Core.sum`
+reduceSum
+  :: ( TensorType a
+     , OneOf '[ Double, Float, Int32, Int64
+            , Complex Float, Complex Double] a
+     )
+  => Tensor v a -> Tensor Build a
+reduceSum x = CoreOps.sum x allAxes
+  where allAxes = CoreOps.range 0 (CoreOps.rank x :: Tensor Build Int32) 1
+
+reduceSum'
+  :: ( TensorType a
+     , OneOf '[ Double, Float, Int32, Int64
+            , Complex Float, Complex Double] a
+     )
+  => OpParams -> Tensor v a -> Tensor Build a
+reduceSum' params x = CoreOps.sum' params x allAxes
+  where allAxes = CoreOps.range 0 (CoreOps.rank x :: Tensor Build Int32) 1
 
 -- | Create a constant vector.
 vector :: TensorType a => [a] -> Tensor Build a

--- a/tensorflow-ops/src/TensorFlow/Ops.hs
+++ b/tensorflow-ops/src/TensorFlow/Ops.hs
@@ -318,21 +318,15 @@ scalarize t = CoreOps.reshape t (vector scalarShape)
 
 -- | Sum a tensor down to a scalar
 -- Seee `TensorFlow.GenOps.Core.sum`
-reduceSum
-  :: ( TensorType a
-     , OneOf '[ Double, Float, Int32, Int64
-            , Complex Float, Complex Double] a
-     )
-  => Tensor v a -> Tensor Build a
+reduceSum :: (OneOf '[ Double, Float, Int32, Int64
+                     , Complex Float, Complex Double] a) =>
+             Tensor v a -> Tensor Build a
 reduceSum x = CoreOps.sum x allAxes
   where allAxes = CoreOps.range 0 (CoreOps.rank x :: Tensor Build Int32) 1
 
-reduceSum'
-  :: ( TensorType a
-     , OneOf '[ Double, Float, Int32, Int64
-            , Complex Float, Complex Double] a
-     )
-  => OpParams -> Tensor v a -> Tensor Build a
+reduceSum' :: (OneOf '[ Double, Float, Int32, Int64
+                      , Complex Float, Complex Double] a) =>
+              OpParams -> Tensor v a -> Tensor Build a
 reduceSum' params x = CoreOps.sum' params x allAxes
   where allAxes = CoreOps.range 0 (CoreOps.rank x :: Tensor Build Int32) 1
 

--- a/tensorflow-ops/tensorflow-ops.cabal
+++ b/tensorflow-ops/tensorflow-ops.cabal
@@ -53,7 +53,7 @@ Test-Suite MatrixTest
   build-depends: base
                , HUnit
                , random
-               , google-shim              
+               , google-shim
                , tensorflow
                , tensorflow-core-ops
                , tensorflow-ops
@@ -62,7 +62,7 @@ Test-Suite MatrixTest
                , test-framework-hunit
                , transformers
                , vector
-                                       
+
 Test-Suite BuildTest
   default-language: Haskell2010
   type: exitcode-stdio-1.0

--- a/tensorflow-ops/tensorflow-ops.cabal
+++ b/tensorflow-ops/tensorflow-ops.cabal
@@ -200,6 +200,7 @@ Test-Suite GradientTest
                , tensorflow-proto
                , test-framework
                , test-framework-hunit
+               , transformers
                , vector
 
 Test-Suite MiscTest


### PR DESCRIPTION
When `matMul` has `transpose_a` or `transpose_b`, the implementation of `opGrad` for `matMul` gives gradients of different shape than the tensors to regard. This shows up when taking second order gradients.

Added Tests for these issues and implemented fix.
The default untransposed `matMul` gradient was ok.

Also implemented gradient of `Tile`