### PR TITLE
Switched to lts-8.13, added custom-setup.

### DIFF
--- a/ci_build/Dockerfile
+++ b/ci_build/Dockerfile
@@ -11,8 +11,6 @@ MAINTAINER TensorFlow authors <tensorflow-haskell@googlegroups.com>
 ADD . /tfhs
 WORKDIR /tfhs
 
-ARG STACK_RESOLVER
-
 RUN \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 575159689BEFB442 && \
     echo 'deb http://download.fpcomplete.com/ubuntu trusty main'| tee /etc/apt/sources.list.d/fpco.list && \
@@ -33,5 +31,5 @@ RUN \
     curl -O https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-1.0.0.tar.gz && \
     tar zxf libtensorflow-cpu-linux-x86_64-1.0.0.tar.gz -C /usr/local && \
     ldconfig && \
-    stack setup --resolver=${STACK_RESOLVER} && \
-    stack test --resolver=${STACK_RESOLVER} --only-dependencies
+    stack setup && \
+    stack test --only-dependencies

--- a/ci_build/outer_launch_tests.sh
+++ b/ci_build/outer_launch_tests.sh
@@ -4,9 +4,8 @@
 
 set -eu -o pipefail
 
-STACK_RESOLVER=${STACK_RESOLVER:-lts-6.2}
-IMAGE_NAME=tensorflow/haskell/ci_build:$STACK_RESOLVER
+IMAGE_NAME=tensorflow/haskell/ci_build:lts8
 
 git submodule update
-docker build --build-arg STACK_RESOLVER=$STACK_RESOLVER -t $IMAGE_NAME -f ci_build/Dockerfile .
-docker run $IMAGE_NAME stack build --resolver=$STACK_RESOLVER --pedantic --test
+docker build -t $IMAGE_NAME -f ci_build/Dockerfile .
+docker run $IMAGE_NAME stack build --pedantic --test

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.6
+resolver: lts-8.13
 
 packages:
 - google-shim

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,19 +17,8 @@ packages:
 - tensorflow-test
 
 extra-deps:
-# proto-lens is not yet in Stackage.
-- proto-lens-0.2.0.1
-- proto-lens-protoc-0.2.0.1
-- proto-lens-descriptors-0.2.0.1
 - snappy-framing-0.1.1
 - snappy-0.2.0.2
-- lens-labels-0.1.0.1
-
-# Allow our custom Setup.hs scripts to import Data.ProtoLens.Setup from the version of
-# `proto-lens-protoc` in stack's local DB.  See:
-# https://github.com/google/proto-lens/blob/master/README.md#using-cabal
-explicit-setup-deps:
-  "*": true
 
 # For Mac OS X, whose linker doesn't use this path by default:
 extra-lib-dirs:

--- a/tensorflow-core-ops/tensorflow-core-ops.cabal
+++ b/tensorflow-core-ops/tensorflow-core-ops.cabal
@@ -9,11 +9,20 @@ maintainer:          tensorflow-haskell@googlegroups.com
 copyright:           Google Inc.
 category:            Machine Learning
 build-type:          Custom
-cabal-version:       >=1.22
+cabal-version:       >=1.24
 
 library
   exposed-modules:  TensorFlow.GenOps.Core
-  build-depends:  Cabal >= 1.22 && < 1.25
+  build-depends:  bytestring
+                , proto-lens == 0.2.*
+                , tensorflow == 0.1.*
+                , base >= 4.7 && < 5
+                , lens-family
+                , text
+  default-language:    Haskell2010
+
+custom-setup
+  setup-depends: Cabal
                 , bytestring
                 , directory
                 , proto-lens == 0.2.*
@@ -22,9 +31,7 @@ library
                 , base >= 4.7 && < 5
                 , filepath
                 , mainland-pretty
-                , lens-family
                 , text
-  default-language:    Haskell2010
 
 source-repository head
   type:     git

--- a/tensorflow-mnist-input-data/tensorflow-mnist-input-data.cabal
+++ b/tensorflow-mnist-input-data/tensorflow-mnist-input-data.cabal
@@ -9,7 +9,7 @@ maintainer:          tensorflow-haskell@googlegroups.com
 copyright:           Google Inc.
 category:            Machine Learning
 build-type:          Custom
-cabal-version:       >=1.22
+cabal-version:       >=1.24
 -- These files are downloaded automatically by Setup.hs. If the
 -- automatic download fails, follow the instructions in error messages
 -- displayed by Setup.hs.
@@ -20,15 +20,18 @@ library
   hs-source-dirs:  src
   exposed-modules: TensorFlow.Examples.MNIST.InputData
   other-modules:   Paths_tensorflow_mnist_input_data
-  build-depends:  Cabal
-                , HTTP
-                , base >= 4.7 && < 5
-                , bytestring
-                , cryptonite
-                , directory
-                , filepath
-                , network-uri
+  build-depends:   base >= 4.7 && < 5
   default-language: Haskell2010
+
+custom-setup
+  setup-depends: Cabal
+               , HTTP
+               , base >= 4.7 && < 5
+               , bytestring
+               , cryptonite
+               , directory
+               , filepath
+               , network-uri
 
 source-repository head
   type:     git

--- a/tensorflow-proto/tensorflow-proto.cabal
+++ b/tensorflow-proto/tensorflow-proto.cabal
@@ -9,7 +9,7 @@ maintainer:          tensorflow-haskell@googlegroups.com
 copyright:           Google Inc.
 category:            Machine Learning
 build-type:          Custom
-cabal-version:       >=1.22
+cabal-version:       >=1.24
 extra-source-files:  ../third_party/tensorflow/tensorflow/core/framework/*.proto
                    , ../third_party/tensorflow/tensorflow/core/protobuf/config.proto
                    , ../third_party/tensorflow/tensorflow/core/protobuf/debug.proto
@@ -40,6 +40,10 @@ library
   default-language:    Haskell2010
   include-dirs: .
 
+custom-setup
+  setup-depends: Cabal
+                , proto-lens-protoc == 0.2.*
+                , base >= 4.7 && < 5
 source-repository head
   type:     git
   location: https://github.com/tensorflow/haskell


### PR DESCRIPTION
Our packages no longer elicit complaints like this:
Package tensorflow-foo uses a custom Cabal build, but does not use a
custom-setup stanza.