### PR TITLE
Increase the number of iterations for MatrixTest.

### DIFF
--- a/tensorflow-ops/tests/MatrixTest.hs
+++ b/tensorflow-ops/tests/MatrixTest.hs
@@ -30,7 +30,7 @@ fitMatrix = testCase "fitMatrix" $ TF.runSession $ do
       diff = matx `TF.sub` (u `TF.matMul` v)
       loss = reduceMean $ TF.square diff
   trainStep <- gradientDescent 0.01 loss [u, v]
-  replicateM_ 300 (TF.run trainStep)
+  replicateM_ 1000 (TF.run trainStep)
   (u',v') <- TF.run (u, v)
   -- ones = u * v
   liftIO $ assertAllClose (V.fromList ones) ((*) <$> u' <*> v')


### PR DESCRIPTION
The number of iterations was reduced from 1000 to 300 during review, but that
turned out to be too low and the test now fails about 20% of the time.
After changing it back to 1000, the test succeeded at 50 out of 50 runs.