### PR TITLE
Work around #92 by always copying TensorData when fetching.

### DIFF
--- a/tensorflow-ops/tests/OpsTest.hs
+++ b/tensorflow-ops/tests/OpsTest.hs
@@ -94,10 +94,22 @@ testScalarFeedCse = testCase "testScalarFeedCse" $ TF.runSession $ do
                 $ p1 `TF.add` p2
     liftIO $ result @=? TF.Scalar 5
 
+-- | See https://github.com/tensorflow/haskell/issues/92.
+-- Even though we're not explicitly evaluating `f0` until the end,
+-- it should hold the earlier value of the variable.
+testRereadRef :: Test
+testRereadRef = testCase "testReRunAssign" $ TF.runSession $ do
+    w <- TF.initializedVariable 0
+    f0 <- TF.run w
+    TF.run_ =<< TF.assign w (TF.scalar (0.1 :: Float))
+    f1 <- TF.run w
+    liftIO $ (0.0, 0.1) @=? (TF.unScalar f0, TF.unScalar f1)
+
 main :: IO ()
 main = googleTest [ testSaveRestore
                   , testSize
                   , testReducedShape
                   , testPlaceholderCse
                   , testScalarFeedCse
+                  , testRereadRef
                   ]


### PR DESCRIPTION
It would be better to avoid the copy when it's not necessary, but
that will require more involved changes to the internal API.  (For example,
Fetchable might need to allow IO or ST actions.)