### PR TITLE
Remove extra-{include,lib}-dirs from stack.yaml.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -16,9 +16,3 @@ packages:
 extra-deps:
 - snappy-framing-0.1.1
 - snappy-0.2.0.2
-
-# For Mac OS X, whose linker doesn't use this path by default:
-extra-lib-dirs:
-    - /usr/local/lib
-extra-include-dirs:
-    - /usr/local/include


### PR DESCRIPTION
As far as I can tell they're not necessary anymore with the current OS X
script that calls `install_name_tool`.  Both "stack test" and "stack ghci"
work without those settings.