### PR TITLE
Add extra-lib-dirs back into .cabal for Mac builds.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -16,3 +16,11 @@ packages:
 extra-deps:
 - snappy-framing-0.1.1
 - snappy-0.2.0.2
+
+# For Mac OS X, whose linker doesn't use this path by default
+# unless you run `xcode-select --install`.
+# TODO: remove this once we stop depending on `snappy`.
+extra-lib-dirs:
+    - /usr/local/lib
+extra-include-dirs:
+    - /usr/local/include

--- a/tensorflow/tensorflow.cabal
+++ b/tensorflow/tensorflow.cabal
@@ -1,5 +1,5 @@
 name:                tensorflow
-version:             0.1.0.1
+version:             0.1.0.2
 synopsis:            TensorFlow bindings.
 description:
     This library provides an interface to the TensorFlow
@@ -61,6 +61,12 @@ library
   extra-libraries:     tensorflow
   default-language:    Haskell2010
   include-dirs: .
+  if os(darwin) {
+    -- The default XCode installation doesn't search this path, so add it
+    -- manually.  Alternately, users can run `xcode-select --install` to add
+    -- it permanently to their search path.
+    extra-lib-dirs: /usr/local/lib
+  }
 
 Test-Suite FFITest
   default-language: Haskell2010


### PR DESCRIPTION
Also bump the version to 0.1.0.2.

Originally we had `extra-lib-dirs: /usr/local/lib` in `stack.yaml`.
I removed it because it wasn't necessary on my Mac.  However,
it turns out that it is necessary for machines with the default installation
of XCode, which *doesn't* search that path by default.

(On my machine, it wasn't necessary because I had run `xcode-select --install`
which adds that path permanently to your search path.)

I'm adding the setting back to `tensorflow.cabal` as well as `stack.yaml` so
that the Hackage release also contains this fix.  Changing `stack.yaml` is
still necessary in order to fix linkage in the `snappy` package (which
`tensorflow-records` depends on).  Hopefully that will go away once we remove
the dependency (#118).