### PR TITLE
Bump version to 0.2.0.0, and start a changelog.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,9 @@
 # ChangeLog
 
 ## Upcoming (v0.2.0.0)
-- Expand the Rendered class to support ResourceHandle wrappers like Variables.
+- Expand the `Rendered` class and add a `ToTensor` class to let more functions
+  (gradients, feed, colocateWith) support `ResourceHandle` wrappers like
+  `Variables`.
 
 ## v0.1.0.2
 - Add extra-lib-dirs for OS X in the Hackage release (#122).

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,13 @@
+# ChangeLog
+
+## Upcoming (v0.2.0.0)
+- Expand the Rendered class to support ResourceHandle wrappers like Variables.
+
+## v0.1.0.2
+- Add extra-lib-dirs for OS X in the Hackage release (#122).
+
+## v0.1.0.1
+- Fix the `tensorflow` sdist release by including `c_api.h`.
+
+## v0.1.0.0
+- Initial release.

--- a/tensorflow/tensorflow.cabal
+++ b/tensorflow/tensorflow.cabal
@@ -1,5 +1,5 @@
 name:                tensorflow
-version:             0.1.0.2
+version:             0.2.0.0
 synopsis:            TensorFlow bindings.
 description:
     This library provides an interface to the TensorFlow

--- a/tensorflow/tensorflow.cabal
+++ b/tensorflow/tensorflow.cabal
@@ -1,5 +1,5 @@
 name:                tensorflow
-version:             0.2.0.0
+version:             0.1.0.2
 synopsis:            TensorFlow bindings.
 description:
     This library provides an interface to the TensorFlow


### PR DESCRIPTION
The HEAD contains #119 which is an API change requiring (as far as I can tell)
a major version bump.