### PR TITLE
Note that we require stack-1.4.0 or newer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ gradientDescent alpha loss params = do
 
 # Installation Instructions
 
+Note: building this repository with `stack` requires version `1.4.0` or newer.
+
 ## Build with Docker on Linux
 
 As an expedient we use [docker](https://www.docker.com/) for building. Once you have docker


### PR DESCRIPTION
This requirement is due to #106 which added Cabal `custom-setup` clauses.