### PR TITLE
Fill out the modules in tensorflow-proto.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -16,6 +16,11 @@ packages:
 extra-deps:
 - snappy-framing-0.1.1
 - snappy-0.2.0.2
+- proto-lens-protobuf-types-0.2.1.0
+# TODO: Remove these once the new versions are in lts-8.
+- proto-lens-0.2.1.0
+- proto-lens-descriptors-0.2.1.0
+- proto-lens-protoc-0.2.1.0
 
 # For Mac OS X, whose linker doesn't use this path by default
 # unless you run `xcode-select --install`.

--- a/tensorflow-proto/tensorflow-proto.cabal
+++ b/tensorflow-proto/tensorflow-proto.cabal
@@ -11,32 +11,54 @@ copyright:           Google Inc.
 category:            Machine Learning
 build-type:          Custom
 cabal-version:       >=1.24
-extra-source-files:  third_party/tensorflow/tensorflow/core/framework/*.proto
-                   , third_party/tensorflow/tensorflow/core/protobuf/config.proto
-                   , third_party/tensorflow/tensorflow/core/protobuf/debug.proto
-                   , third_party/tensorflow/tensorflow/core/util/event.proto
+extra-source-files:  third_party/tensorflow/tensorflow/core/example/*.proto
+                   , third_party/tensorflow/tensorflow/core/framework/*.proto
+                   , third_party/tensorflow/tensorflow/core/lib/core/error_codes.proto
+                   , third_party/tensorflow/tensorflow/core/protobuf/*.proto
+                   , third_party/tensorflow/tensorflow/core/util/*.proto
 
 library
-  exposed-modules:     Proto.Tensorflow.Core.Framework.AttrValue
+  exposed-modules:     Proto.Tensorflow.Core.Example.Example
+                     , Proto.Tensorflow.Core.Example.ExampleParserConfiguration
+                     , Proto.Tensorflow.Core.Example.Feature
+                     , Proto.Tensorflow.Core.Framework.AllocationDescription
+                     , Proto.Tensorflow.Core.Framework.AttrValue
+                     , Proto.Tensorflow.Core.Framework.CostGraph
+                     , Proto.Tensorflow.Core.Framework.DeviceAttributes
+                     , Proto.Tensorflow.Core.Framework.Function
                      , Proto.Tensorflow.Core.Framework.Graph
+                     , Proto.Tensorflow.Core.Framework.KernelDef
+                     , Proto.Tensorflow.Core.Framework.LogMemory
                      , Proto.Tensorflow.Core.Framework.NodeDef
                      , Proto.Tensorflow.Core.Framework.OpDef
                      , Proto.Tensorflow.Core.Framework.ResourceHandle
+                     , Proto.Tensorflow.Core.Framework.StepStats
                      , Proto.Tensorflow.Core.Framework.Summary
                      , Proto.Tensorflow.Core.Framework.Tensor
-                     , Proto.Tensorflow.Core.Framework.TensorShape
-                     , Proto.Tensorflow.Core.Framework.Types
-                     , Proto.Tensorflow.Core.Protobuf.Config
-                     , Proto.Tensorflow.Core.Util.Event
-  other-modules:       Proto.Tensorflow.Core.Framework.AllocationDescription
-                     , Proto.Tensorflow.Core.Framework.CostGraph
-                     , Proto.Tensorflow.Core.Framework.Function
-                     , Proto.Tensorflow.Core.Framework.StepStats
                      , Proto.Tensorflow.Core.Framework.TensorDescription
+                     , Proto.Tensorflow.Core.Framework.TensorShape
+                     , Proto.Tensorflow.Core.Framework.TensorSlice
+                     , Proto.Tensorflow.Core.Framework.Types
+                     , Proto.Tensorflow.Core.Framework.Variable
                      , Proto.Tensorflow.Core.Framework.Versions
+                     , Proto.Tensorflow.Core.Lib.Core.ErrorCodes
+                     , Proto.Tensorflow.Core.Protobuf.Config
+                     , Proto.Tensorflow.Core.Protobuf.ControlFlow
                      , Proto.Tensorflow.Core.Protobuf.Debug
+                     , Proto.Tensorflow.Core.Protobuf.MetaGraph
+                     , Proto.Tensorflow.Core.Protobuf.NamedTensor
+                     , Proto.Tensorflow.Core.Protobuf.QueueRunner
+                     , Proto.Tensorflow.Core.Protobuf.TensorBundle
+                     , Proto.Tensorflow.Core.Protobuf.SavedModel
+                     , Proto.Tensorflow.Core.Protobuf.Saver
+                     , Proto.Tensorflow.Core.Protobuf.TensorflowServer
+                     , Proto.Tensorflow.Core.Util.Event
+                     , Proto.Tensorflow.Core.Util.MemmappedFileSystem
+                     , Proto.Tensorflow.Core.Util.SavedTensorSlice
+                     , Proto.Tensorflow.Core.Util.TestLog
   build-depends:  proto-lens == 0.2.*
                 , proto-lens-protoc == 0.2.*
+                , proto-lens-protobuf-types == 0.2.*
                 , base >= 4.7 && < 5
   default-language:    Haskell2010
   include-dirs: .

--- a/tensorflow-proto/tensorflow-proto.cabal
+++ b/tensorflow-proto/tensorflow-proto.cabal
@@ -57,7 +57,7 @@ library
                      , Proto.Tensorflow.Core.Util.SavedTensorSlice
                      , Proto.Tensorflow.Core.Util.TestLog
   build-depends:  proto-lens == 0.2.*
-                , proto-lens-protoc == 0.2.*
+                , proto-lens-protoc >= 0.2.1 && < 0.3
                 , proto-lens-protobuf-types == 0.2.*
                 , base >= 4.7 && < 5
   default-language:    Haskell2010


### PR DESCRIPTION
That package now includes everything in the `tensorflow/core:protos_all` target:
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/BUILD#L131

I also made all of the modules exposed for simplicity.  (As a particular
example: `MetaGraph`, which was previously in `other-modules`, is useful for
constructing some TensorFlow serving RPCs.)