### PR TITLE
Fix the build with ghc-8.2.1.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -20,7 +20,8 @@ extra-deps:
 - proto-lens-protobuf-types-0.2.2.0
 - proto-lens-0.2.2.0
 - proto-lens-descriptors-0.2.2.0
-- proto-lens-protoc-0.2.2.1
+- proto-lens-protoc-0.2.2.3
+- lens-labels-0.1.0.2
 
 # For Mac OS X, whose linker doesn't use this path by default
 # unless you run `xcode-select --install`.

--- a/tensorflow-core-ops/Setup.hs
+++ b/tensorflow-core-ops/Setup.hs
@@ -11,6 +11,7 @@
 -- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
+{-# LANGUAGE CPP #-}
 
 -- | Generates the wrappers for Ops shipped with tensorflow.
 module Main where
@@ -20,7 +21,7 @@ import Distribution.PackageDescription
     , libBuildInfo
     , hsSourceDirs
     )
-import Distribution.Simple.BuildPaths (autogenModulesDir)
+import qualified Distribution.Simple.BuildPaths as BuildPaths
 import Distribution.Simple.LocalBuildInfo (LocalBuildInfo)
 import Distribution.Simple
     ( defaultMainWithHooks
@@ -91,3 +92,10 @@ blackList =
     [ -- Requires the "func" type:
       "SymbolicGradient"
     ]
+
+autogenModulesDir :: LocalBuildInfo -> FilePath
+#if MIN_VERSION_Cabal(2,0,0)
+autogenModulesDir = BuildPaths.autogenPackageModulesDir
+#else
+autogenModulesDir = BuildPaths.autogenModulesDir
+#endif


### PR DESCRIPTION
- Avoid using a deprecated Cabal function
- Use newer versions of proto-lens packages in stack.yaml
- Work around a new type-level warning that affects `OneOf/TensorTypes`.