### PR TITLE
Create monad transformer version of Session (closes #153)

### DIFF
--- a/tensorflow/src/TensorFlow/Internal/FFI.hs
+++ b/tensorflow/src/TensorFlow/Internal/FFI.hs
@@ -33,8 +33,9 @@ module TensorFlow.Internal.FFI
 
 import Control.Concurrent.Async (Async, async, cancel, waitCatch)
 import Control.Concurrent.MVar (MVar, modifyMVarMasked_, newMVar, takeMVar)
-import Control.Exception (Exception, throwIO, bracket, finally, mask_)
 import Control.Monad (when)
+import Control.Monad.Catch (MonadMask, Exception, throwM, bracket, finally, mask_)
+import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.Bits (Bits, toIntegralSized)
 import Data.Int (Int64)
 import Data.Maybe (fromMaybe)
@@ -75,13 +76,14 @@ data TensorData = TensorData
 
 -- | Runs the given action after creating a session with options
 -- populated by the given optionSetter.
-withSession :: (Raw.SessionOptions -> IO ())
-            -> ((IO () -> IO ()) -> Raw.Session -> IO a)
+withSession :: (MonadIO m, MonadMask m)
+            => (Raw.SessionOptions -> IO ())
+            -> ((IO () -> IO ()) -> Raw.Session -> m a)
             -- ^ The action can spawn concurrent tasks which will
             -- be canceled before withSession returns.
-            -> IO a
+            -> m a
 withSession optionSetter action = do
-    drain <- newMVar []
+    drain <- liftIO $ newMVar []
     let cleanup s =
         -- Closes the session to nudge the pending run calls to fail and exit.
             finally (checkStatus (Raw.closeSession s)) $ do
@@ -89,11 +91,11 @@ withSession optionSetter action = do
                 -- Collects all runners before deleting the session.
                 mapM_ shutDownRunner runners
                 checkStatus (Raw.deleteSession s)
-    bracket Raw.newSessionOptions Raw.deleteSessionOptions $ \options -> do
-        optionSetter options
+    bracket (liftIO $ Raw.newSessionOptions) (liftIO . Raw.deleteSessionOptions) $ \options -> do
+        liftIO $ optionSetter options
         bracket
-            (checkStatus (Raw.newSession options))
-            cleanup
+            (liftIO $ checkStatus (Raw.newSession options))
+            (liftIO . cleanup)
             (action (asyncCollector drain))
 
 asyncCollector :: MVar [Async ()] -> IO () -> IO ()
@@ -225,7 +227,7 @@ checkStatus fn =
         when (code /= Raw.TF_OK) $ do
             msg <- T.decodeUtf8With T.lenientDecode <$>
                    (Raw.message status >>= B.packCString)
-            throwIO $ TensorFlowException code msg
+            throwM $ TensorFlowException code msg
         return result
 
 setSessionConfig :: ConfigProto -> Raw.SessionOptions -> IO ()
@@ -258,7 +260,7 @@ getAllOpList = do
     where
       checkCall = do
           p <- Raw.getAllOpList
-          when (p == nullPtr) (throwIO exception)
+          when (p == nullPtr) (throwM exception)
           return p
       exception = TensorFlowException
                 Raw.TF_UNKNOWN "GetAllOpList failure, check logs"


### PR DESCRIPTION
`Session` was already a monad transformer stack, which is now also exported. All other signatures have become a bit more generic but are all backwards compatible.