### PR TITLE
Fix initialized variables for tensorflow 1.7

### DIFF
--- a/tensorflow-ops/tests/VariableTest.hs
+++ b/tensorflow-ops/tests/VariableTest.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedLists #-}
 module Main (main) where
 
+import Data.Int (Int32)
 import Data.Maybe (isJust)
 import Control.Monad (when)
 import Control.Monad.IO.Class (liftIO)
@@ -55,6 +56,8 @@ testInitializedVariableShape =
         vector <- initializedVariable (Ops.constant [1] [42 :: Float])
         result <- run (readValue vector)
         liftIO $ [42] @=? (result :: V.Vector Float)
+        s <- run (Ops.shape (readValue vector))
+        liftIO $ [1] @=? (s :: V.Vector Int32)
 
 testInitializedValue :: Test
 testInitializedValue =


### PR DESCRIPTION
This is needed to support tensorflow 1.7. The trick of initializing a
variable with `Shape []` and then overriding the shape by assigning an
initial value no longer works. It seems that we need to explicitly flip
the `unknown_rank` bit in the shape proto.

I thought about switching opgen to use `Maybe Shape` when an op requires
a shape attribute, but that will cause a lot of api churn, so I chose to
hold off for now and just do a spot fix to unblock 1.7.

The new test assert already passes in the current version, but fails in 1.7.