### PR TITLE
Update to tensorflow 1.8

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,7 @@
 # ChangeLog
 
 ## Upcoming (v0.2.0.0)
-- Switch to tensorflow 1.7.
+- Switch to tensorflow 1.8.
 - Expand the `Rendered` class and add a `ToTensor` class to let more functions
   (gradients, feed, colocateWith) support `ResourceHandle` wrappers like
   `Variables`.

--- a/ci_build/Dockerfile
+++ b/ci_build/Dockerfile
@@ -3,7 +3,7 @@
 # stack to be installed on the host.  This comes at the expense of
 # flexibility.
 
-FROM tensorflow/tensorflow:1.7.0
+FROM tensorflow/tensorflow:1.8.0
 LABEL maintainer="TensorFlow authors <tensorflow-haskell@googlegroups.com>"
 
 # The build context directory is the top of the tensorflow-haskell
@@ -28,8 +28,8 @@ RUN \
     curl -O -L https://github.com/google/protobuf/releases/download/v3.2.0/protoc-3.2.0-linux-x86_64.zip && \
     unzip -d /usr/local protoc-3.2.0-linux-x86_64.zip bin/protoc && \
     chmod 755 /usr/local/bin/protoc && \
-    curl -O https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-1.7.0.tar.gz && \
-    tar zxf libtensorflow-cpu-linux-x86_64-1.7.0.tar.gz -C /usr/local && \
+    curl -O https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-1.8.0.tar.gz && \
+    tar zxf libtensorflow-cpu-linux-x86_64-1.8.0.tar.gz -C /usr/local && \
     ldconfig && \
     stack setup && \
     stack test --only-dependencies

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # Prepare the image with:
 #   docker build -t tensorflow/haskell:v0 docker
-FROM tensorflow/tensorflow:1.7.0
+FROM tensorflow/tensorflow:1.8.0
 LABEL maintainer="TensorFlow authors <tensorflow-haskell@googlegroups.com>"
 
 RUN apt-get update
@@ -27,8 +27,8 @@ RUN \
     curl -O -L https://github.com/google/protobuf/releases/download/v3.2.0/protoc-3.2.0-linux-x86_64.zip && \
     unzip -d /usr/local protoc-3.2.0-linux-x86_64.zip bin/protoc && \
     chmod 755 /usr/local/bin/protoc && \
-    curl -O https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-1.7.0.tar.gz && \
-    tar zxf libtensorflow-cpu-linux-x86_64-1.7.0.tar.gz -C /usr/local && \
+    curl -O https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-1.8.0.tar.gz && \
+    tar zxf libtensorflow-cpu-linux-x86_64-1.8.0.tar.gz -C /usr/local && \
     ldconfig
 
 ENV LANG en_US.UTF-8

--- a/docker/gpu/Dockerfile
+++ b/docker/gpu/Dockerfile
@@ -1,6 +1,6 @@
 # Prepare the image with:
-#   docker build -t tensorflow/haskell:1.3.0-gpu docker/gpu
-FROM gcr.io/tensorflow/tensorflow:1.3.0-gpu
+#   docker build -t tensorflow/haskell:1.8.0-gpu docker/gpu
+FROM gcr.io/tensorflow/tensorflow:1.8.0-gpu
 LABEL maintainer="TensorFlow authors <tensorflow-haskell@googlegroups.com>"
 
 RUN apt-get update
@@ -27,8 +27,8 @@ RUN \
     curl -O -L https://github.com/google/protobuf/releases/download/v3.2.0/protoc-3.2.0-linux-x86_64.zip && \
     unzip -d /usr/local protoc-3.2.0-linux-x86_64.zip bin/protoc && \
     chmod 755 /usr/local/bin/protoc && \
-    curl -O https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-1.3.0.tar.gz && \
-    tar zxf libtensorflow-gpu-linux-x86_64-1.3.0.tar.gz -C /usr/local && \
+    curl -O https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-1.8.0.tar.gz && \
+    tar zxf libtensorflow-gpu-linux-x86_64-1.8.0.tar.gz -C /usr/local && \
     ldconfig
 
 ENV LANG en_US.UTF-8

--- a/tensorflow-core-ops/Setup.hs
+++ b/tensorflow-core-ops/Setup.hs
@@ -92,8 +92,10 @@ blackList =
     [ -- Requires the "func" type:
       "FilterDataset"
     , "FlatMapDataset"
+    , "For"
     , "GeneratorDataset"
     , "GroupByWindowDataset"
+    , "If"
     , "InterleaveDataset"
     , "MapAndBatchDataset"
     , "MapDataset"
@@ -104,6 +106,8 @@ blackList =
     , "RemoteCall"
     , "ScanDataset"
     , "SymbolicGradient"
+    , "TPUReplicate"
+    , "While"
     , "_If"
     , "_While"
     ]

--- a/tools/install_macos_dependencies.sh
+++ b/tools/install_macos_dependencies.sh
@@ -25,7 +25,7 @@ else
 fi
 
 echo "Downloading libtensorflow..."
-curl https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-darwin-x86_64-1.7.0.tar.gz > libtensorflow.tar.gz
+curl https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-darwin-x86_64-1.8.0.tar.gz > libtensorflow.tar.gz
 
 echo "Extracting and copying libtensorflow..."
 sudo tar zxf libtensorflow.tar.gz -C /usr/local

--- a/tools/userchroot.nix
+++ b/tools/userchroot.nix
@@ -13,8 +13,8 @@ let
     name = "tensorflow-c";
 
     src = fetchurl {
-      url = "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-1.7.0.tar.gz";
-      sha256 = "621642b1fddd3831e048817d2220d9d7cf8ba359ac81c83a808bcdd9a982ee90";
+      url = "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-1.8.0.tar.gz";
+      sha256 = "0a8e334d7c20879df9857c762472329d70cbf2f316af113d0b26f5c17209fe63";
     };
 
     buildCommand = ''


### PR DESCRIPTION
Updates to tensorflow 1.8. Follows in the footsteps of the commit updating tensorflow to 1.7 (1e2dca870125a2941359f14f5e02971a28d6e199). I have only done light testing, but it seems to work.

(Not sure about the update to the change log. Maybe you'd like to release a version using 1.7 first?)