### PR TITLE
Use newer version of stack in CI

### DIFF
--- a/ci_build/Dockerfile
+++ b/ci_build/Dockerfile
@@ -12,6 +12,7 @@ ADD . /tfhs
 WORKDIR /tfhs
 
 RUN \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 575159689BEFB442 && \
     apt-get update && \
     apt-get install -y \
         # Required by snappy-frames dependency.

--- a/ci_build/Dockerfile
+++ b/ci_build/Dockerfile
@@ -12,8 +12,6 @@ ADD . /tfhs
 WORKDIR /tfhs
 
 RUN \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 575159689BEFB442 && \
-    echo 'deb http://download.fpcomplete.com/ubuntu trusty main'| tee /etc/apt/sources.list.d/fpco.list && \
     apt-get update && \
     apt-get install -y \
         # Required by snappy-frames dependency.
@@ -23,7 +21,12 @@ RUN \
         # Makes stack viable in the container
         libgmp-dev \
         libcurl3-dev \
-        stack && \
+        # Required for tcp connections by stack (See: https://github.com/tensorflow/haskell/issues/182)
+        netbase \
+        && \
+    # Installs stack.
+    curl -O -L https://github.com/commercialhaskell/stack/releases/download/v1.7.1/stack-1.7.1-linux-x86_64.tar.gz && \
+    tar zxf stack-1.7.1-linux-x86_64.tar.gz -C /usr/local/bin stack-1.7.1-linux-x86_64/stack --strip 1 && \
     # Installs protoc and the libraries.
     curl -O -L https://github.com/google/protobuf/releases/download/v3.2.0/protoc-3.2.0-linux-x86_64.zip && \
     unzip -d /usr/local protoc-3.2.0-linux-x86_64.zip bin/protoc && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get install -y \
         libgmp-dev \
         # Required for locales configuration.
         locales \
-        # Required for tcp connections (See: https://github.com/tensorflow/haskell/issues/182)
+        # Required for tcp connections by stack (See: https://github.com/tensorflow/haskell/issues/182)
         netbase
 
 # Our MNIST demo program outputs Unicode characters.

--- a/tensorflow-ops/tests/GradientTest.hs
+++ b/tensorflow-ops/tests/GradientTest.hs
@@ -392,9 +392,9 @@ transAttrs a b =
 testConv2DBackpropInputGrad :: Test
 testConv2DBackpropInputGrad = testCase "testConv2DBackpropInputGrad" $ do
     (dx, shapeDX, shapeX) <- TF.runSession $ do
-        let convInputShape = TF.vector [1, 2, 2, 1 :: Int32] -- [batch, h, w, in_channels]
-        let convOutShape = TF.vector [1, 1, 1, 1 :: Int32]  -- [batch, h, w, out_channels]
-        x <- TF.render $ TF.fill convOutShape (TF.scalar (1::Float))
+        let conv_input_shape = TF.vector [1, 2, 2, 1 :: Int32] -- [batch, h, w, in_channels]
+        let conv_out_shape = TF.vector [1, 1, 1, 1 :: Int32]  -- [batch, h, w, out_channels]
+        x <- TF.render $ TF.fill conv_out_shape (TF.scalar (1::Float))
 
         let filterShape = TF.vector [2, 2, 1, 1 :: Int32] -- [fh, fw, inc, out]
         filter' <- TF.render $ TF.fill filterShape (TF.scalar (1::Float))
@@ -403,7 +403,7 @@ testConv2DBackpropInputGrad = testCase "testConv2DBackpropInputGrad" $ do
                 . (TF.opAttr "padding" .~ (BS.pack "VALID"))
                 . (TF.opAttr "data_format" .~ (BS.pack "NHWC"))
                 )
-                convInputShape filter' x
+                conv_input_shape filter' x
 
         [dx] <- TF.gradients y [x]
         TF.run (dx, TF.shape dx, TF.shape x)

--- a/tensorflow-ops/tests/GradientTest.hs
+++ b/tensorflow-ops/tests/GradientTest.hs
@@ -392,18 +392,18 @@ transAttrs a b =
 testConv2DBackpropInputGrad :: Test
 testConv2DBackpropInputGrad = testCase "testConv2DBackpropInputGrad" $ do
     (dx, shapeDX, shapeX) <- TF.runSession $ do
-        let conv_input_shape = TF.vector [1, 2, 2, 1 :: Int32] -- [batch, h, w, in_channels]
-        let conv_out_shape = TF.vector [1, 1, 1, 1 :: Int32]  -- [batch, h, w, out_channels]
-        x <- TF.render $ TF.fill conv_out_shape (TF.scalar (1::Float))
+        let convInputShape = TF.vector [1, 2, 2, 1 :: Int32] -- [batch, h, w, in_channels]
+        let convOutShape = TF.vector [1, 1, 1, 1 :: Int32]  -- [batch, h, w, out_channels]
+        x <- TF.render $ TF.fill convOutShape (TF.scalar (1::Float))
 
         let filterShape = TF.vector [2, 2, 1, 1 :: Int32] -- [fh, fw, inc, out]
-        filter <- TF.render $ TF.fill filterShape (TF.scalar (1::Float))
+        filter' <- TF.render $ TF.fill filterShape (TF.scalar (1::Float))
         let y = TF.conv2DBackpropInput'
                 ( (TF.opAttr "strides" .~ [1::Int64, 1, 1, 1])
                 . (TF.opAttr "padding" .~ (BS.pack "VALID"))
                 . (TF.opAttr "data_format" .~ (BS.pack "NHWC"))
                 )
-                conv_input_shape filter x
+                convInputShape filter' x
 
         [dx] <- TF.gradients y [x]
         TF.run (dx, TF.shape dx, TF.shape x)


### PR DESCRIPTION
Required by #187.

The version we were using is old enough that it doesn't work with the
latest stackage LTS. haskellstack.org says

    There is also a Ubuntu package for Ubuntu 16.10 and up, but the
    distribution's Stack version lags behind, ...

So, instead of asking them to update it, it's probably better to
download the tar of the version we want.

Somehow updating stack surfaced a new pedantic warning in GradientTest,
so I've fixed that as well (and cleaned up some code using snake_case).