### PR TITLE
Fix install script for High Sierra

### DIFF
--- a/tools/install_macos_dependencies.sh
+++ b/tools/install_macos_dependencies.sh
@@ -28,11 +28,12 @@ echo "Downloading libtensorflow..."
 curl https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-darwin-x86_64-1.8.0.tar.gz > libtensorflow.tar.gz
 
 echo "Extracting and copying libtensorflow..."
-tar zxf libtensorflow.tar.gz -C .
-sudo rsync -a lib/ /usr/local/lib
-sudo rsync -a include/ /usr/local/include
+TMP_DIR=`mktemp -d`
+tar zxf libtensorflow.tar.gz -C $TMP_DIR
+sudo rsync -a $TMP_DIR/lib/ /usr/local/lib
+sudo rsync -a $TMP_DIR/include/ /usr/local/include
 rm libtensorflow.tar.gz
-rm -rf lib/ include/
+rm -rf $TMP_DIR
 sudo mv /usr/local/lib/libtensorflow.so /usr/local/lib/libtensorflow.dylib
 
 sudo install_name_tool -id libtensorflow.dylib /usr/local/lib/libtensorflow.dylib

--- a/tools/install_macos_dependencies.sh
+++ b/tools/install_macos_dependencies.sh
@@ -28,8 +28,11 @@ echo "Downloading libtensorflow..."
 curl https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-darwin-x86_64-1.8.0.tar.gz > libtensorflow.tar.gz
 
 echo "Extracting and copying libtensorflow..."
-sudo tar zxf libtensorflow.tar.gz -C /usr/local
+tar zxf libtensorflow.tar.gz -C .
+sudo rsync -a lib/ /usr/local/lib
+sudo rsync -a include/ /usr/local/include
 rm libtensorflow.tar.gz
+rm -rf lib/ include/
 sudo mv /usr/local/lib/libtensorflow.so /usr/local/lib/libtensorflow.dylib
 
 sudo install_name_tool -id libtensorflow.dylib /usr/local/lib/libtensorflow.dylib

--- a/tools/install_macos_dependencies.sh
+++ b/tools/install_macos_dependencies.sh
@@ -24,16 +24,16 @@ else
     brew install snappy
 fi
 
+TMP_DIR=$(mktemp -d)
+
 echo "Downloading libtensorflow..."
-curl https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-darwin-x86_64-1.8.0.tar.gz > libtensorflow.tar.gz
+curl https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-darwin-x86_64-1.8.0.tar.gz > "$TMP_DIR/libtensorflow.tar.gz"
 
 echo "Extracting and copying libtensorflow..."
-TMP_DIR=`mktemp -d`
-tar zxf libtensorflow.tar.gz -C $TMP_DIR
-sudo rsync -a $TMP_DIR/lib/ /usr/local/lib
-sudo rsync -a $TMP_DIR/include/ /usr/local/include
-rm libtensorflow.tar.gz
-rm -rf $TMP_DIR
+tar zxf "$TMP_DIR/libtensorflow.tar.gz" -C "$TMP_DIR"
+sudo rsync -a "$TMP_DIR/lib/" /usr/local/lib
+sudo rsync -a "$TMP_DIR/include/" /usr/local/include
+rm -rf "$TMP_DIR"
 sudo mv /usr/local/lib/libtensorflow.so /usr/local/lib/libtensorflow.dylib
 
 sudo install_name_tool -id libtensorflow.dylib /usr/local/lib/libtensorflow.dylib


### PR DESCRIPTION
Hi,

this is a small fix that allows a clean installation on OSX High Sierra/Sierra/El Capitan due to the limitations Apple introduced to write to /usr folder even for root.