### PR TITLE
Simplified shell.nix

### DIFF
--- a/nix/src.json
+++ b/nix/src.json
@@ -1,6 +1,6 @@
 {
   "owner": "NixOS",
   "repo": "nixpkgs",
-  "rev": "729da53a147eda1a1678a313754fcda3a8791279",
-  "sha256": "17l19rbhb3wdrrcyjgq34bk3p658jbldzxp9q1scdvrvz0g99psb"
+  "rev": "7098bcac278a2d028036bb3a23508fd1c52155ac",
+  "sha256": "04m7z7334mjma0ci3vp4js6rbz4s2jxy864s1v4dkdm7860zjc28"
 }

--- a/shell.nix
+++ b/shell.nix
@@ -2,54 +2,18 @@
 
 let
   # Use pinned packages
-  _nixpkgs = import <nixpkgs> {};
-  nixpkgs = _nixpkgs.fetchFromGitHub (_nixpkgs.lib.importJSON ./nix/src.json);
+  nixpkgs = with (builtins.fromJSON (builtins.readFile ./nix/src.json));
+    builtins.fetchTarball {
+      url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
+      inherit sha256;
+    };
+
   pkgs = import nixpkgs {};
-
-  # Either use specified GHC or use GHC 8.2.2 (which we need for LTS 11.9)
-  myghc = if isNull ghc then pkgs.haskell.compiler.ghc822 else ghc;
-
-  # Fetch tensorflow library
-  tensorflow-c = pkgs.stdenv.mkDerivation {
-    name = "tensorflow-c";
-    src = pkgs.fetchurl {
-      url = "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-1.8.0.tar.gz";
-      sha256 = "0qzy15rc3x961cyi3bqnygrcnw4x69r28xkwhpwrv1r0gi6k73ha";
-    };
-
-    # Patch library to use our libc, libstdc++ and others
-    buildCommand = ''
-      . $stdenv/setup
-      mkdir -pv $out
-      tar -C $out -xzf $src
-      chmod +w $out/lib/libtensorflow.so
-      ${pkgs.patchelf}/bin/patchelf --set-rpath "${pkgs.stdenv.cc.libc}/lib:${pkgs.stdenv.cc.cc.lib}/lib" $out/lib/libtensorflow.so
-      chmod -w $out/lib/libtensorflow.so
-    '';
-  };
-
-  # Wrapped stack executable that uses the nix-provided GHC
-  stack = pkgs.stdenv.mkDerivation {
-      name = "stack-system-ghc";
-      builder = pkgs.writeScript "stack" ''
-        source $stdenv/setup
-        mkdir -p $out/bin
-        makeWrapper ${pkgs.stack}/bin/stack $out/bin/stack \
-          --add-flags --system-ghc
-      '';
-      buildInputs = [ pkgs.makeWrapper ];
-    };
 in
   pkgs.haskell.lib.buildStackProject {
-    ghc = myghc;
-    stack = stack;
+    # Either use specified GHC or use GHC 8.2.2 (which we need for LTS 11.9)
+    ghc = if isNull ghc then pkgs.haskell.compiler.ghc822 else ghc;
+    extraArgs = "--system-ghc";
     name = "tf-env";
-    buildInputs =
-        [
-          pkgs.snappy
-          pkgs.zlib
-          pkgs.protobuf3_3
-          tensorflow-c
-          stack
-        ];
+    buildInputs = with pkgs; [ snappy zlib protobuf libtensorflow ];
   }


### PR DESCRIPTION
* I upgraded nixpkgs to the [latest master which now contains `libtensorflow`](https://github.com/NixOS/nixpkgs/blob/7098bcac278a2d028036bb3a23508fd1c52155ac/pkgs/development/libraries/libtensorflow/default.nix). This replaces the custom `tensorflow-c`. Note that `libtensorflow` now also builds on OS X and has optional CUDA support.

* nixpkgs is now pinned using `builtins.fetchTarball` which means we can build with an empty `NIX_PATH` thus making the build pure.

  This does require Nix-2.0 but this has been released for a while with NixOS-18.03.

* The stack override has been replaced by passing `extraArgs = "--system-ghc";` to `buildStackProject`.

BTW I also added [overrides for the tensorflow-haskell packages to nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/configuration-tensorflow-ghc-8.2.x.nix). This means that the following now builds:

```shell
for pkg in tensorflow tensorflow-proto tensorflow-core-ops tensorflow-logging tensorflow-mnist; do 
  nix-build -A haskell.packages.ghc822.$pkg; 
done
```
