### PR TITLE
Update README link to point to the most recent release docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is not an official Google product.
 
 https://tensorflow.github.io/haskell/haddock/
 
-[TensorFlow.Core](https://tensorflow.github.io/haskell/haddock/tensorflow-0.1.0.2/TensorFlow-Core.html)
+[TensorFlow.Core](https://tensorflow.github.io/haskell/haddock/tensorflow/TensorFlow-Core.html)
 is a good place to start.
 
 # Examples

--- a/tools/haddock.sh
+++ b/tools/haddock.sh
@@ -15,4 +15,5 @@ mkdir -p $DOCS
 cp $DOC_ROOT/{*.html,*js,*.png,*.gif,*.css} $DOCS
 cp -a $DOC_ROOT/tensorflow* $DOCS
 rm -f $DOCS/*/*.haddock
+ln -s $DOCS/tensorflow-* $DOCS/tensorflow
 git add $DOCS


### PR DESCRIPTION
Hello.

I was reading the README and clicked on the link to see `TensorFlow.Core` and the link took me to a 404 page. The URL had `0.1.0.2` and when I changed it to the latest release version everything worked.