### PR TITLE
add setup/deployment script and description for CentOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,21 @@ After running the script to install system dependencies, build the project with 
 
     stack test
 
+## Build on CentOS (native OS with stack)
+
+1. install `stack` with version >1.4.0
+
+2. run the [install_centos_dependencies.sh](./tools/install_centos_dependencies.sh)
+script in the `tools/` directory to install dependencies.
+- Protocol Buffers (git version to support the latest build with GHC 8.4.4)
+- Snappy (install via `yum`)
+- libtensorflow (deployed to `/usr/lib64/` and `/usr/include`)
+
+3. test with this library repo via `stack test`
+
+4. develop your own project with `resolver: lts-12.26` in the `stack.yaml` file
+   and an `extra-deps` entry pointed to this repo.
+
 ## Build on NixOS
 
 The `shell.nix` provides an environment containing the necessary

--- a/tools/install_centos_dependencies.sh
+++ b/tools/install_centos_dependencies.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+echo "Installing CentOS 7.6 Dependencies"
+echo "=================================="
+
+# Basic environment
+echo "Checking basic tools..."
+sudo yum install wget git -y
+
+# Protocol Buffers
+echo "Preparing compiling environment..."
+sudo yum install autoconf automake libtool unzip gcc-c++ -y
+TMP_DIR=$(mktemp -d)
+pushd $TMP_DIR
+echo "Downloading protobuf..." 
+git clone https://github.com/google/protobuf.git
+sudo rm -rf /usr/local/src/protobuf
+sudo mv protobuf /usr/local/src/
+pushd /usr/local/src/protobuf
+git submodule update --init --recursive
+./autogen.sh
+./configure --prefix=/usr
+make
+sudo make install
+popd
+popd
+
+# snappy
+echo "Installing snappy..."
+sudo yum install snappy -y
+
+# libtensorflow
+TMP_DIR=$(mktemp -d)
+pushd $TMP_DIR
+echo "Downloading libtensorflow..."
+wget https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-1.9.0.tar.gz
+echo "Installing libtensorflow..."
+tar zxf libtensorflow-cpu-linux-x86_64-1.9.0.tar.gz
+sudo cp -r lib/* /usr/lib64/
+sudo cp -r include/* /usr/include/
+sudo ldconfig
+popd
+
+echo ""
+echo "Finished"


### PR DESCRIPTION
I am using the tensorflow Haskell binding on CentOS with stack only (no Docker or Nix). And I think it would be convenient to automatically setup the running environment when someone else uses it. So I put up a dependency solving script similar to the MacOS one and add description to `README.md`. The environment is set for stack resolver lts-12.26 with GHC 8.4.4 and everything is consistent with the latest version in this git repo. The script is tested via `stack test` with success. Feel free to let me know if I need to revise anything before the merge.