### PR TITLE
Add gradient for slice function

### DIFF
--- a/tensorflow-ops/src/TensorFlow/Gradient.hs
+++ b/tensorflow-ops/src/TensorFlow/Gradient.hs
@@ -711,7 +711,7 @@ opGrad "Pad" _ [toT -> x, toT -> padPattern] [dz] =
     gradientSliceSize = shape (x :: Tensor Build Float)
 
 -- Gradient for Slice
--- Create an Nx2 padding where N ist the rank of (grad of) Slice and the first
+-- Create an Nx2 padding where N is the rank of (grad of) Slice and the first
 -- column represents how many zeros are to be prepended for each dimension, and the second
 -- column indicates how many zeros are appended.
 -- The number of zeros to prepend is the shape of the beginvec.
@@ -723,13 +723,13 @@ opGrad "Slice" _ [toT -> inputvec, toT -> beginvec, _] [dz] =
    [Just $ CoreOps.pad dz paddings, Nothing, Nothing]
   where
     v1 = vector [1 :: Int32]
-    input_rank' = CoreOps.rank (inputvec :: Tensor Build Float)
-    -- For some reason input_rank' has an empty shape
-    input_rank = CoreOps.reshape input_rank' v1
-    pad_shape = CoreOps.concat 0 [input_rank, v1]
-    beforepad = CoreOps.reshape beginvec pad_shape
-    afterpad = CoreOps.reshape (shape inputvec - shape dz - beginvec) pad_shape
-    paddings = CoreOps.concat 1 [beforepad, afterpad]
+    inputRank' = CoreOps.rank (inputvec :: Tensor Build Float)
+    -- For some reason inputRank' has an empty shape
+    inputRank = CoreOps.reshape inputRank' v1
+    padShape = CoreOps.concat 0 [inputRank, v1]
+    beforePad = CoreOps.reshape beginvec padShape
+    afterPad = CoreOps.reshape (shape inputvec - shape dz - beginvec) padShape
+    paddings = CoreOps.concat 1 [beforePad, afterPad]
 
 -- TODO: This could be either Int32 or Int64.
 opGrad "BatchToSpaceND" _ [_, toT @Int32 -> blockShape, toT @Int32 -> crops] [dz] =

--- a/tensorflow-ops/tests/GradientTest.hs
+++ b/tensorflow-ops/tests/GradientTest.hs
@@ -32,9 +32,9 @@ import Control.Monad(forM_, replicateM, zipWithM)
 import Control.Monad.IO.Class (liftIO)
 
 import qualified TensorFlow.Core as TF
-import qualified TensorFlow.GenOps.Core as TF (conv2DBackpropInput', max, maximum, tile, pad, batchToSpaceND, spaceToBatchND, squeeze, sqrt)
+import qualified TensorFlow.GenOps.Core as TF (conv2DBackpropInput', max, maximum, tile, pad, batchToSpaceND, spaceToBatchND, squeeze, sqrt, slice, shape)
 import qualified TensorFlow.Gradient as TF
-import qualified TensorFlow.Ops as TF hiding (zeroInitializedVariable)
+import qualified TensorFlow.Ops as TF hiding (zeroInitializedVariable, shape)
 import qualified TensorFlow.Output as TF
 import qualified TensorFlow.Types as TF
 import qualified TensorFlow.Variable as TF
@@ -324,6 +324,7 @@ testPad =
     V.fromList [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1] @=? dx
     V.fromList [2, 2, 3] @=? s
 
+
 testSqrt :: Test
 testSqrt = testCase "testSqrt" $ do
     [dx] <- TF.runSession $ do
@@ -331,6 +332,18 @@ testSqrt = testCase "testSqrt" $ do
         let y = TF.sqrt x
         TF.gradients y [x] >>= TF.run
     V.fromList [2] @=? dx
+
+testSlice :: Test
+testSlice =
+  testCase "testSlice" $ do
+    ([dx], [s]) <-
+      TF.runSession $ do
+        (x :: TF.Tensor TF.Value Float) <- TF.render $ TF.zeros $ TF.Shape [2, 3, 4 :: Int64]
+        (z :: TF.Tensor TF.Value Float) <- TF.render $ TF.zeros $ TF.Shape [1, 2, 2 :: Int64]
+        let y = TF.slice x (TF.constant (TF.Shape [3]) [1, 1, 1 :: Int32]) (TF.shape z)
+        calculateGradWithShape y x
+    V.fromList [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 1, 0] @=? dx
+    V.fromList [2, 3, 4] @=? s
 
 testBatchToSpaceND :: Test
 testBatchToSpaceND =
@@ -526,6 +539,7 @@ main = defaultMain
             , testReshape
             , testPad
             , testSqrt
+            , testSlice
             , testBatchToSpaceND
             , testSpaceToBatchND
             , testSqueeze

--- a/tensorflow-ops/tests/GradientTest.hs
+++ b/tensorflow-ops/tests/GradientTest.hs
@@ -342,7 +342,14 @@ testSlice =
         (z :: TF.Tensor TF.Value Float) <- TF.render $ TF.zeros $ TF.Shape [1, 2, 2 :: Int64]
         let y = TF.slice x (TF.constant (TF.Shape [3]) [1, 1, 1 :: Int32]) (TF.shape z)
         calculateGradWithShape y x
-    V.fromList [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 1, 0] @=? dx
+    let expected =
+         [0, 0, 0, 0,
+          0, 0, 0, 0,
+          0, 0, 0, 0,
+          0, 0, 0, 0,
+          0, 1, 1, 0,
+          0, 1, 1, 0]
+    V.fromList expected @=? dx
     V.fromList [2, 3, 4] @=? s
 
 testBatchToSpaceND :: Test


### PR DESCRIPTION
I added the gradient for the slice function in tensorflow / haskell. Please check if the implementation is right. I used the version in python for template, see array_grad.py.

The CLA is signed by the manager of my company, Active Group GmbH. Please let me know if more info is needed (same as with pull requests by @rikvdkleij).