### PR TITLE
Bump version constraints for proto-lens-*

### DIFF
--- a/tensorflow-core-ops/tensorflow-core-ops.cabal
+++ b/tensorflow-core-ops/tensorflow-core-ops.cabal
@@ -15,7 +15,7 @@ cabal-version:       >=1.24
 library
   exposed-modules:  TensorFlow.GenOps.Core
   build-depends:  bytestring
-                , proto-lens == 0.4.*
+                , proto-lens >= 0.4.0 && < 0.6.0
                 , tensorflow == 0.2.*
                 , base >= 4.7 && < 5
                 , lens-family
@@ -26,7 +26,7 @@ custom-setup
   setup-depends: Cabal
                 , bytestring
                 , directory
-                , proto-lens == 0.4.*
+                , proto-lens >= 0.4.0 && < 0.6.0
                 , tensorflow-opgen == 0.2.*
                 , tensorflow == 0.2.*
                 , base >= 4.7 && < 5

--- a/tensorflow-logging/tensorflow-logging.cabal
+++ b/tensorflow-logging/tensorflow-logging.cabal
@@ -24,7 +24,7 @@ library
                 , filepath
                 , hostname
                 , lens-family
-                , proto-lens == 0.4.*
+                , proto-lens >= 0.4.0 && < 0.6.0
                 , resourcet
                 , stm
                 , stm-chans

--- a/tensorflow-mnist/tensorflow-mnist.cabal
+++ b/tensorflow-mnist/tensorflow-mnist.cabal
@@ -20,7 +20,7 @@ library
   exposed-modules: TensorFlow.Examples.MNIST.Parse
                 ,  TensorFlow.Examples.MNIST.TrainedGraph
   other-modules:  Paths_tensorflow_mnist
-  build-depends:  proto-lens == 0.4.*
+  build-depends: proto-lens >= 0.4.0 && < 0.6.0
                 , base >= 4.7 && < 5
                 , binary
                 , bytestring

--- a/tensorflow-opgen/tensorflow-opgen.cabal
+++ b/tensorflow-opgen/tensorflow-opgen.cabal
@@ -16,7 +16,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     TensorFlow.OpGen.ParsedOp
                      , TensorFlow.OpGen
-  build-depends:  proto-lens == 0.4.*
+  build-depends:  proto-lens >= 0.4.0 && < 0.6.0
                 , tensorflow-proto == 0.2.*
                 , base >= 4.7 && < 5
                 , bytestring

--- a/tensorflow-ops/tensorflow-ops.cabal
+++ b/tensorflow-ops/tensorflow-ops.cabal
@@ -21,7 +21,7 @@ library
                  , TensorFlow.NN
                  , TensorFlow.Queue
                  , TensorFlow.Variable
-  build-depends:  proto-lens == 0.4.*
+  build-depends:  proto-lens >= 0.4.0 && < 0.6.0
                 , base >= 4.7 && < 5
                 , bytestring
                 , fgl

--- a/tensorflow-proto/tensorflow-proto.cabal
+++ b/tensorflow-proto/tensorflow-proto.cabal
@@ -97,9 +97,9 @@ library
                      , Proto.Tensorflow.Core.Util.SavedTensorSlice_Fields
                      , Proto.Tensorflow.Core.Util.TestLog
                      , Proto.Tensorflow.Core.Util.TestLog_Fields
-  build-depends:  proto-lens == 0.4.*
-                , proto-lens-runtime == 0.4.*
-                , proto-lens-protobuf-types == 0.4.*
+  build-depends:  proto-lens >= 0.4.0 && < 0.6.0
+                , proto-lens-runtime >= 0.4.0 && < 0.6.0
+                , proto-lens-protobuf-types >= 0.4.0 && < 0.6.0
                 , base >= 4.7 && < 5
   default-language:    Haskell2010
   include-dirs: .

--- a/tensorflow/tensorflow.cabal
+++ b/tensorflow/tensorflow.cabal
@@ -36,7 +36,7 @@ library
                   , TensorFlow.Types
   other-modules:    TensorFlow.Internal.Raw
   build-tools:      c2hs
-  build-depends:  proto-lens == 0.4.*
+  build-depends:  proto-lens >= 0.4.0 && < 0.6.0
                 , tensorflow-proto == 0.2.*
                 , base >= 4.7 && < 5
                 , async


### PR DESCRIPTION
I confirmed that it still builds with 0.5.