### PR TITLE
nix updated to be compatible with LTS14.4

### DIFF
--- a/nix/src.json
+++ b/nix/src.json
@@ -1,6 +1,6 @@
 {
   "owner": "NixOS",
   "repo": "nixpkgs",
-  "rev": "dbb9f8818af7cf2ea91b89f7d80a8fb1800cbfb5",
-  "sha256": "1i8lsiscjzq066p02a5c7azjrvqxqkz6dipzkkyhh9rmhgs1aca3"
+  "rev": "8731aaaf8b30888bc24994096db830993090d7c4",
+  "sha256": "1hcc89rxi47nb0mpk05nl9rbbb04kfw97xfydhpmmgh57yrp3zqa"
 }

--- a/nix/update
+++ b/nix/update
@@ -7,7 +7,7 @@ set -euo pipefail
 
 cd "$(dirname "$0")" || exit 1
 
-branch=release-18.04
+branch=release-19.09
 
 owner=NixOS
 repo=nixpkgs

--- a/shell.nix
+++ b/shell.nix
@@ -11,8 +11,8 @@ let
   pkgs = import nixpkgs {};
 in
   pkgs.haskell.lib.buildStackProject {
-    # Either use specified GHC or use GHC 8.6.4 (which we need for LTS 13.13)
-    ghc = if isNull ghc then pkgs.haskell.compiler.ghc864 else ghc;
+    # Either use specified GHC or use GHC 8.6.5 (which we need for LTS 14.4)
+    ghc = if isNull ghc then pkgs.haskell.compiler.ghc865 else ghc;
     extraArgs = "--system-ghc";
     name = "tf-env";
     buildInputs = with pkgs; [ snappy zlib protobuf libtensorflow ];


### PR DESCRIPTION
With @curiousleo, we have noticed some outdated versions in installation by nix. 
We did the following changes:
* `nix/update` updated to pull from the nix release `19.09`
* `shell.nix` updated to use `ghc865` as default for `ghc` (since `LTS14.4` uses `ghc865`).