### PR TITLE
Updates the build badge path to the new location.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Build Status](https://storage.googleapis.com/tensorflow-haskell-kokoro-build-badges/github.png)
+![Build Status](https://storage.googleapis.com/tensorflow-kokoro-build-badges/haskell/github.png)
 
 The tensorflow-haskell package provides Haskell bindings to
 [TensorFlow](https://www.tensorflow.org/).


### PR DESCRIPTION
We can share the GCS bucket for build badges with other TensorFlow repositories.

Underlying migration is still in progress and please do not merge until the badge appears on the new location.