### PR TITLE
Update to TensorFlow 2.10.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ working, the following commands will compile and run the tests.
 ```
 git clone --recursive https://github.com/tensorflow/haskell.git tensorflow-haskell
 cd tensorflow-haskell
-docker build -t tensorflow/haskell:2.3.0 docker
+docker build -t tensorflow/haskell:2.10.1 docker
 # TODO: move the setup step to the docker script.
 stack --docker setup
 stack --docker test
@@ -90,7 +90,7 @@ stack --docker build --exec Main
 If you want to use GPU you can do:
 
 ```
-IMAGE_NAME=tensorflow/haskell:2.3.0-gpu
+IMAGE_NAME=tensorflow/haskell:2.10.1-gpu
 docker build -t $IMAGE_NAME docker/gpu
 # TODO: move the setup step to the docker script.
 stack --docker --docker-image=$IMAGE_NAME setup

--- a/ci_build/Dockerfile
+++ b/ci_build/Dockerfile
@@ -3,7 +3,7 @@
 # stack to be installed on the host.  This comes at the expense of
 # flexibility.
 
-FROM tensorflow/tensorflow:2.3.0
+FROM tensorflow/tensorflow:2.10.1
 LABEL maintainer="TensorFlow authors <tensorflow-haskell@googlegroups.com>"
 
 # The build context directory is the top of the tensorflow-haskell
@@ -36,8 +36,8 @@ RUN \
     curl -O -L https://github.com/google/protobuf/releases/download/v3.13.0/protoc-3.13.0-linux-x86_64.zip && \
     unzip -d /usr/local protoc-3.13.0-linux-x86_64.zip bin/protoc && \
     chmod 755 /usr/local/bin/protoc && \
-    curl -O https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-2.3.0.tar.gz && \
-    tar zxf libtensorflow-cpu-linux-x86_64-2.3.0.tar.gz -C /usr/local && \
+    curl -O https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-2.10.1.tar.gz && \
+    tar zxf libtensorflow-cpu-linux-x86_64-2.10.1.tar.gz -C /usr/local && \
     ldconfig && \
     stack setup && \
     stack test --only-dependencies

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # Prepare the image with:
-#   docker build -t tensorflow/haskell:2.3.0 docker
-FROM tensorflow/tensorflow:2.3.0
+#   docker build -t tensorflow/haskell:2.10.1 docker
+FROM tensorflow/tensorflow:2.10.1
 LABEL maintainer="TensorFlow authors <tensorflow-haskell@googlegroups.com>"
 
 RUN apt-get update
@@ -31,8 +31,8 @@ RUN \
     curl -O -L https://github.com/google/protobuf/releases/download/v3.13.0/protoc-3.13.0-linux-x86_64.zip && \
     unzip -d /usr/local protoc-3.13.0-linux-x86_64.zip bin/protoc && \
     chmod 755 /usr/local/bin/protoc && \
-    curl -O https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-2.3.0.tar.gz && \
-    tar zxf libtensorflow-cpu-linux-x86_64-2.3.0.tar.gz -C /usr/local && \
+    curl -O https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-2.10.1.tar.gz && \
+    tar zxf libtensorflow-cpu-linux-x86_64-2.10.1.tar.gz -C /usr/local && \
     ldconfig
 
 ENV LANG en_US.UTF-8

--- a/docker/gpu/Dockerfile
+++ b/docker/gpu/Dockerfile
@@ -1,6 +1,6 @@
 # Prepare the image with:
-#   docker build -t tensorflow/haskell:2.3.0-gpu docker/gpu
-FROM tensorflow/tensorflow:2.3.0-gpu
+#   docker build -t tensorflow/haskell:2.10.1-gpu docker/gpu
+FROM tensorflow/tensorflow:2.10.1-gpu
 LABEL maintainer="TensorFlow authors <tensorflow-haskell@googlegroups.com>"
 
 RUN apt-get update
@@ -31,8 +31,8 @@ RUN \
     curl -O -L https://github.com/google/protobuf/releases/download/v3.13.0/protoc-3.13.0-linux-x86_64.zip && \
     unzip -d /usr/local protoc-3.13.0-linux-x86_64.zip bin/protoc && \
     chmod 755 /usr/local/bin/protoc && \
-    curl -O https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-2.3.0.tar.gz && \
-    tar zxf libtensorflow-gpu-linux-x86_64-2.3.0.tar.gz -C /usr/local && \
+    curl -O https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-2.10.1.tar.gz && \
+    tar zxf libtensorflow-gpu-linux-x86_64-2.10.1.tar.gz -C /usr/local && \
     ldconfig
 
 ENV LANG en_US.UTF-8

--- a/stack.yaml
+++ b/stack.yaml
@@ -29,7 +29,7 @@ extra-include-dirs:
 
 docker:
     enable: false
-    image: tensorflow/haskell:2.3.0
+    image: tensorflow/haskell:2.10.1
 
 nix:
     enable: false

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,8 +14,10 @@ packages:
 - tensorflow-test
 
 extra-deps:
-- snappy-framing-0.1.2
+- c2hs-0.28.8
+- language-c-0.9.2
 - snappy-0.2.0.2
+- snappy-framing-0.1.2
 
 # For Mac OS X, whose linker doesn't use this path by default
 # unless you run `xcode-select --install`.

--- a/stack.yaml
+++ b/stack.yaml
@@ -33,6 +33,6 @@ docker:
 
 nix:
     enable: false
-    # nixos-21.05 with libtensorflow 2.3.0
-    path: ["nixpkgs=https://github.com/NixOS/nixpkgs/archive/c7cb72b0cae397d311236d6773338efb4bd4f2d1.tar.gz"]
-    packages: [snappy, zlib, protobuf, python3Packages.tensorflow_2.libtensorflow]
+    # nixos-22.11 with libtensorflow 2.10.1
+    path: ["nixpkgs=https://github.com/NixOS/nixpkgs/archive/2dea8991d89b9f1e78d874945f78ca15f6954289.tar.gz"]
+    packages: [snappy, zlib, protobuf, libtensorflow]

--- a/tensorflow-core-ops/Setup.hs
+++ b/tensorflow-core-ops/Setup.hs
@@ -148,6 +148,16 @@ blackList =
     , "_TPUReplicate"
     , "_While"
     , "_XlaCompile"
+    -- Incorrectly generated:
+    , "_FusedBatchNormGradEx"
+    -- Could not deduce:
+    , "_MklFusedBatchNorm"
+    , "_MklFusedBatchNormEx"
+    , "_MklFusedBatchNormGrad"
+    , "_MklFusedBatchNormGradV2"
+    , "_MklFusedBatchNormGradV3"
+    , "_MklFusedBatchNormV2"
+    , "_MklFusedBatchNormV3"
     ]
 
 autogenModulesDir :: LocalBuildInfo -> FilePath

--- a/tensorflow-core-ops/tensorflow-core-ops.cabal
+++ b/tensorflow-core-ops/tensorflow-core-ops.cabal
@@ -10,7 +10,7 @@ maintainer:          tensorflow-haskell@googlegroups.com
 copyright:           Google Inc.
 category:            Machine Learning
 build-type:          Custom
-cabal-version:       >=2.0
+cabal-version:       2.0
 
 library
   exposed-modules:  TensorFlow.GenOps.Core

--- a/tensorflow-logging/tensorflow-logging.cabal
+++ b/tensorflow-logging/tensorflow-logging.cabal
@@ -10,7 +10,7 @@ maintainer:          tensorflow-haskell@googlegroups.com
 copyright:           Google Inc.
 category:            Machine Learning
 build-type:          Simple
-cabal-version:       >=1.22
+cabal-version:       2.0
 
 library
   hs-source-dirs:   src

--- a/tensorflow-mnist-input-data/tensorflow-mnist-input-data.cabal
+++ b/tensorflow-mnist-input-data/tensorflow-mnist-input-data.cabal
@@ -10,7 +10,7 @@ maintainer:          tensorflow-haskell@googlegroups.com
 copyright:           Google Inc.
 category:            Machine Learning
 build-type:          Custom
-cabal-version:       >=1.24
+cabal-version:       2.0
 -- These files are downloaded automatically by Setup.hs. If the
 -- automatic download fails, follow the instructions in error messages
 -- displayed by Setup.hs.

--- a/tensorflow-mnist/tensorflow-mnist.cabal
+++ b/tensorflow-mnist/tensorflow-mnist.cabal
@@ -10,7 +10,7 @@ maintainer:          tensorflow-haskell@googlegroups.com
 copyright:           Google Inc.
 category:            Machine Learning
 build-type:          Simple
-cabal-version:       >=1.22
+cabal-version:       2.0
 data-files:          data/*.ckpt
                    , data/*.pb
 

--- a/tensorflow-opgen/tensorflow-opgen.cabal
+++ b/tensorflow-opgen/tensorflow-opgen.cabal
@@ -10,7 +10,7 @@ maintainer:          tensorflow-haskell@googlegroups.com
 copyright:           Google Inc.
 category:            Machine Learning
 build-type:          Simple
-cabal-version:       >=1.22
+cabal-version:       2.0
 
 library
   hs-source-dirs:      src

--- a/tensorflow-ops/tensorflow-ops.cabal
+++ b/tensorflow-ops/tensorflow-ops.cabal
@@ -10,7 +10,7 @@ maintainer:          tensorflow-haskell@googlegroups.com
 copyright:           Google Inc.
 category:            Machine Learning
 build-type:          Simple
-cabal-version:       >=1.22
+cabal-version:       2.0
 
 library
   hs-source-dirs:   src

--- a/tensorflow-proto/tensorflow-proto.cabal
+++ b/tensorflow-proto/tensorflow-proto.cabal
@@ -11,14 +11,126 @@ copyright:           Google Inc.
 category:            Machine Learning
 build-type:          Custom
 cabal-version:       2.0
-extra-source-files:  third_party/tensorflow/tensorflow/core/example/*.proto
+extra-source-files:  third_party/tensorflow/tensorflow/compiler/jit/*.proto
+                   , third_party/tensorflow/tensorflow/compiler/mlir/lite/quantization/*.proto
+                   , third_party/tensorflow/tensorflow/compiler/mlir/quantization/tensorflow/*.proto
+                   , third_party/tensorflow/tensorflow/compiler/mlir/tfrt/analysis/*.proto
+                   , third_party/tensorflow/tensorflow/compiler/mlir/tools/kernel_gen/*.proto
+                   , third_party/tensorflow/tensorflow/compiler/tf2tensorrt/utils/*.proto
+                   , third_party/tensorflow/tensorflow/compiler/tf2xla/*.proto
+                   , third_party/tensorflow/tensorflow/compiler/tf2xla/kernels/*.proto
+                   , third_party/tensorflow/tensorflow/compiler/xla/*.proto
+                   , third_party/tensorflow/tensorflow/compiler/xla/pjrt/distributed/*.proto
+                   , third_party/tensorflow/tensorflow/compiler/xla/python/tpu_driver/*.proto
+                   , third_party/tensorflow/tensorflow/compiler/xla/rpc/*.proto
+                   , third_party/tensorflow/tensorflow/compiler/xla/service/*.proto
+                   , third_party/tensorflow/tensorflow/compiler/xla/service/gpu/*.proto
+                   , third_party/tensorflow/tensorflow/compiler/xla/tools/*.proto
+                   , third_party/tensorflow/tensorflow/compiler/xrt/*.proto
+                   , third_party/tensorflow/tensorflow/core/data/*.proto
+                   , third_party/tensorflow/tensorflow/core/data/service/*.proto
+                   , third_party/tensorflow/tensorflow/core/debug/*.proto
+                   , third_party/tensorflow/tensorflow/core/example/*.proto
                    , third_party/tensorflow/tensorflow/core/framework/*.proto
-                   , third_party/tensorflow/tensorflow/core/lib/core/error_codes.proto
+                   , third_party/tensorflow/tensorflow/core/function/trace_type/*.proto
+                   , third_party/tensorflow/tensorflow/core/grappler/costs/*.proto
+                   , third_party/tensorflow/tensorflow/core/grappler/optimizers/inference/*.proto
+                   , third_party/tensorflow/tensorflow/core/lib/core/*.proto
+                   , third_party/tensorflow/tensorflow/core/profiler/*.proto
+                   , third_party/tensorflow/tensorflow/core/profiler/protobuf/*.proto
                    , third_party/tensorflow/tensorflow/core/protobuf/*.proto
+                   , third_party/tensorflow/tensorflow/core/protobuf/tpu/*.proto
+                   , third_party/tensorflow/tensorflow/core/tfrt/fallback/*.proto
+                   , third_party/tensorflow/tensorflow/core/tpu/kernels/*.proto
                    , third_party/tensorflow/tensorflow/core/util/*.proto
+                   , third_party/tensorflow/tensorflow/core/util/autotune_maps/*.proto
+                   , third_party/tensorflow/tensorflow/distribute/experimental/rpc/proto/*.proto
+                   , third_party/tensorflow/tensorflow/dtensor/proto/*.proto
+                   , third_party/tensorflow/tensorflow/lite/experimental/acceleration/configuration/*.proto
+                   , third_party/tensorflow/tensorflow/lite/python/metrics/*.proto
+                   , third_party/tensorflow/tensorflow/lite/toco/*.proto
+                   , third_party/tensorflow/tensorflow/lite/toco/logging/*.proto
+                   , third_party/tensorflow/tensorflow/lite/tools/evaluation/proto/*.proto
+                   , third_party/tensorflow/tensorflow/python/framework/*.proto
+                   , third_party/tensorflow/tensorflow/python/keras/protobuf/*.proto
+                   , third_party/tensorflow/tensorflow/python/kernel_tests/proto/*.proto
+                   , third_party/tensorflow/tensorflow/python/tpu/*.proto
+                   , third_party/tensorflow/tensorflow/python/training/*.proto
+                   , third_party/tensorflow/tensorflow/python/util/protobuf/*.proto
+                   , third_party/tensorflow/tensorflow/security/fuzzing/*.proto
+                   , third_party/tensorflow/tensorflow/stream_executor/*.proto
+                   , third_party/tensorflow/tensorflow/tools/api/lib/*.proto
+                   , third_party/tensorflow/tensorflow/tools/proto_text/*.proto
+
 
 library
-  exposed-modules:     Proto.Tensorflow.Core.Example.Example
+  exposed-modules:     Proto.Tensorflow.Compiler.Jit.XlaActivity
+                     , Proto.Tensorflow.Compiler.Jit.XlaActivity_Fields
+                     , Proto.Tensorflow.Compiler.Jit.XlaCompilationCache
+                     , Proto.Tensorflow.Compiler.Jit.XlaCompilationCache_Fields
+                     , Proto.Tensorflow.Compiler.Mlir.Lite.Quantization.QuantizationInfo
+                     , Proto.Tensorflow.Compiler.Mlir.Lite.Quantization.QuantizationInfo_Fields
+                     , Proto.Tensorflow.Compiler.Mlir.Quantization.Tensorflow.QuantizationOptions
+                     , Proto.Tensorflow.Compiler.Mlir.Quantization.Tensorflow.QuantizationOptions_Fields
+                     , Proto.Tensorflow.Compiler.Mlir.Tfrt.Analysis.Analysis
+                     , Proto.Tensorflow.Compiler.Mlir.Tfrt.Analysis.Analysis_Fields
+                     , Proto.Tensorflow.Compiler.Mlir.Tools.KernelGen.CompileCacheItem
+                     , Proto.Tensorflow.Compiler.Mlir.Tools.KernelGen.CompileCacheItem_Fields
+                     , Proto.Tensorflow.Compiler.Tf2tensorrt.Utils.TrtEngineInstance
+                     , Proto.Tensorflow.Compiler.Tf2tensorrt.Utils.TrtEngineInstance_Fields
+                     , Proto.Tensorflow.Compiler.Tf2xla.HostComputeMetadata
+                     , Proto.Tensorflow.Compiler.Tf2xla.HostComputeMetadata_Fields
+                     , Proto.Tensorflow.Compiler.Tf2xla.Kernels.Callback
+                     , Proto.Tensorflow.Compiler.Tf2xla.Kernels.Callback_Fields
+                     , Proto.Tensorflow.Compiler.Tf2xla.Support
+                     , Proto.Tensorflow.Compiler.Tf2xla.Support_Fields
+                     , Proto.Tensorflow.Compiler.Tf2xla.Tf2xla
+                     , Proto.Tensorflow.Compiler.Tf2xla.Tf2xla_Fields
+                     , Proto.Tensorflow.Compiler.Xla.Pjrt.Distributed.Protocol
+                     , Proto.Tensorflow.Compiler.Xla.Pjrt.Distributed.Protocol_Fields
+                     , Proto.Tensorflow.Compiler.Xla.Python.TpuDriver.TpuDriver
+                     , Proto.Tensorflow.Compiler.Xla.Python.TpuDriver.TpuDriver_Fields
+                     , Proto.Tensorflow.Compiler.Xla.Python.TpuDriver.TpuService
+                     , Proto.Tensorflow.Compiler.Xla.Python.TpuDriver.TpuService_Fields
+                     , Proto.Tensorflow.Compiler.Xla.Rpc.XlaService
+                     , Proto.Tensorflow.Compiler.Xla.Rpc.XlaService_Fields
+                     , Proto.Tensorflow.Compiler.Xla.Service.Gpu.BackendConfigs
+                     , Proto.Tensorflow.Compiler.Xla.Service.Gpu.BackendConfigs_Fields
+                     , Proto.Tensorflow.Compiler.Xla.Service.Gpu.GpuAutotuning
+                     , Proto.Tensorflow.Compiler.Xla.Service.Gpu.GpuAutotuning_Fields
+                     , Proto.Tensorflow.Compiler.Xla.Service.Hlo
+                     , Proto.Tensorflow.Compiler.Xla.Service.Hlo_Fields
+                     , Proto.Tensorflow.Compiler.Xla.Service.HloExecutionProfileData
+                     , Proto.Tensorflow.Compiler.Xla.Service.HloExecutionProfileData_Fields
+                     , Proto.Tensorflow.Compiler.Xla.Service.HloProfilePrinterData
+                     , Proto.Tensorflow.Compiler.Xla.Service.HloProfilePrinterData_Fields
+                     , Proto.Tensorflow.Compiler.Xla.Service.TestCompilationEnvironment
+                     , Proto.Tensorflow.Compiler.Xla.Service.TestCompilationEnvironment_Fields
+                     , Proto.Tensorflow.Compiler.Xla.Tools.RunHloModule
+                     , Proto.Tensorflow.Compiler.Xla.Tools.RunHloModule_Fields
+                     , Proto.Tensorflow.Compiler.Xla.Xla
+                     , Proto.Tensorflow.Compiler.Xla.Xla_Fields
+                     , Proto.Tensorflow.Compiler.Xla.XlaData
+                     , Proto.Tensorflow.Compiler.Xla.XlaData_Fields
+                     , Proto.Tensorflow.Compiler.Xrt.Xrt
+                     , Proto.Tensorflow.Compiler.Xrt.Xrt_Fields
+                     , Proto.Tensorflow.Core.Data.Dataset
+                     , Proto.Tensorflow.Core.Data.Dataset_Fields
+                     , Proto.Tensorflow.Core.Data.Service.Common
+                     , Proto.Tensorflow.Core.Data.Service.Common_Fields
+                     , Proto.Tensorflow.Core.Data.Service.Dispatcher
+                     , Proto.Tensorflow.Core.Data.Service.Dispatcher_Fields
+                     , Proto.Tensorflow.Core.Data.Service.Export
+                     , Proto.Tensorflow.Core.Data.Service.Export_Fields
+                     , Proto.Tensorflow.Core.Data.Service.Journal
+                     , Proto.Tensorflow.Core.Data.Service.Journal_Fields
+                     , Proto.Tensorflow.Core.Data.Service.Worker
+                     , Proto.Tensorflow.Core.Data.Service.Worker_Fields
+                     , Proto.Tensorflow.Core.Debug.DebugService
+                     , Proto.Tensorflow.Core.Debug.DebugService_Fields
+                     , Proto.Tensorflow.Core.Debug.DebuggerEventMetadata
+                     , Proto.Tensorflow.Core.Debug.DebuggerEventMetadata_Fields
+                     , Proto.Tensorflow.Core.Example.Example
                      , Proto.Tensorflow.Core.Example.Example_Fields
                      , Proto.Tensorflow.Core.Example.ExampleParserConfiguration
                      , Proto.Tensorflow.Core.Example.ExampleParserConfiguration_Fields
@@ -26,24 +138,38 @@ library
                      , Proto.Tensorflow.Core.Example.Feature_Fields
                      , Proto.Tensorflow.Core.Framework.AllocationDescription
                      , Proto.Tensorflow.Core.Framework.AllocationDescription_Fields
+                     , Proto.Tensorflow.Core.Framework.ApiDef
+                     , Proto.Tensorflow.Core.Framework.ApiDef_Fields
                      , Proto.Tensorflow.Core.Framework.AttrValue
                      , Proto.Tensorflow.Core.Framework.AttrValue_Fields
                      , Proto.Tensorflow.Core.Framework.CostGraph
                      , Proto.Tensorflow.Core.Framework.CostGraph_Fields
+                     , Proto.Tensorflow.Core.Framework.DatasetMetadata
+                     , Proto.Tensorflow.Core.Framework.DatasetMetadata_Fields
+                     , Proto.Tensorflow.Core.Framework.DatasetOptions
+                     , Proto.Tensorflow.Core.Framework.DatasetOptions_Fields
                      , Proto.Tensorflow.Core.Framework.DeviceAttributes
                      , Proto.Tensorflow.Core.Framework.DeviceAttributes_Fields
+                     , Proto.Tensorflow.Core.Framework.FullType
+                     , Proto.Tensorflow.Core.Framework.FullType_Fields
                      , Proto.Tensorflow.Core.Framework.Function
                      , Proto.Tensorflow.Core.Framework.Function_Fields
                      , Proto.Tensorflow.Core.Framework.Graph
                      , Proto.Tensorflow.Core.Framework.Graph_Fields
+                     , Proto.Tensorflow.Core.Framework.GraphTransferInfo
+                     , Proto.Tensorflow.Core.Framework.GraphTransferInfo_Fields
                      , Proto.Tensorflow.Core.Framework.KernelDef
                      , Proto.Tensorflow.Core.Framework.KernelDef_Fields
                      , Proto.Tensorflow.Core.Framework.LogMemory
                      , Proto.Tensorflow.Core.Framework.LogMemory_Fields
+                     , Proto.Tensorflow.Core.Framework.Model
+                     , Proto.Tensorflow.Core.Framework.Model_Fields
                      , Proto.Tensorflow.Core.Framework.NodeDef
                      , Proto.Tensorflow.Core.Framework.NodeDef_Fields
                      , Proto.Tensorflow.Core.Framework.OpDef
                      , Proto.Tensorflow.Core.Framework.OpDef_Fields
+                     , Proto.Tensorflow.Core.Framework.ReaderBase
+                     , Proto.Tensorflow.Core.Framework.ReaderBase_Fields
                      , Proto.Tensorflow.Core.Framework.ResourceHandle
                      , Proto.Tensorflow.Core.Framework.ResourceHandle_Fields
                      , Proto.Tensorflow.Core.Framework.StepStats
@@ -64,46 +190,307 @@ library
                      , Proto.Tensorflow.Core.Framework.Variable_Fields
                      , Proto.Tensorflow.Core.Framework.Versions
                      , Proto.Tensorflow.Core.Framework.Versions_Fields
+                     , Proto.Tensorflow.Core.Function.TraceType.DefaultTypes
+                     , Proto.Tensorflow.Core.Function.TraceType.DefaultTypes_Fields
+                     , Proto.Tensorflow.Core.Function.TraceType.Serialization
+                     , Proto.Tensorflow.Core.Function.TraceType.Serialization_Fields
+                     , Proto.Tensorflow.Core.Function.TraceType.SerializationTest
+                     , Proto.Tensorflow.Core.Function.TraceType.SerializationTest_Fields
+                     , Proto.Tensorflow.Core.Grappler.Costs.OpPerformanceData
+                     , Proto.Tensorflow.Core.Grappler.Costs.OpPerformanceData_Fields
+                     , Proto.Tensorflow.Core.Grappler.Optimizers.Inference.BatchOpRewriter
+                     , Proto.Tensorflow.Core.Grappler.Optimizers.Inference.BatchOpRewriter_Fields
                      , Proto.Tensorflow.Core.Lib.Core.ErrorCodes
+                     , Proto.Tensorflow.Core.Lib.Core.ErrorCodes_Fields
+                     , Proto.Tensorflow.Core.Profiler.Profile
+                     , Proto.Tensorflow.Core.Profiler.Profile_Fields
+                     , Proto.Tensorflow.Core.Profiler.ProfilerAnalysis
+                     , Proto.Tensorflow.Core.Profiler.ProfilerAnalysis_Fields
+                     , Proto.Tensorflow.Core.Profiler.ProfilerOptions
+                     , Proto.Tensorflow.Core.Profiler.ProfilerOptions_Fields
+                     , Proto.Tensorflow.Core.Profiler.ProfilerService
+                     , Proto.Tensorflow.Core.Profiler.ProfilerService_Fields
+                     , Proto.Tensorflow.Core.Profiler.ProfilerServiceMonitorResult
+                     , Proto.Tensorflow.Core.Profiler.ProfilerServiceMonitorResult_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.Diagnostics
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.Diagnostics_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.HardwareTypes
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.HardwareTypes_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.InputPipeline
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.InputPipeline_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.KernelStats
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.KernelStats_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.MemoryProfile
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.MemoryProfile_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.MemoryViewerPreprocess
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.MemoryViewerPreprocess_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.OpMetrics
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.OpMetrics_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.OpProfile
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.OpProfile_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.OpStats
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.OpStats_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.OverviewPage
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.OverviewPage_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.PodStats
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.PodStats_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.PodViewer
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.PodViewer_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.StepsDb
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.StepsDb_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.TfDataStats
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.TfDataStats_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.TfFunction
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.TfFunction_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.TfStats
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.TfStats_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.Tfstreamz
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.Tfstreamz_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.TraceEvents
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.TraceEvents_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.Xplane
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.Xplane_Fields
+                     , Proto.Tensorflow.Core.Profiler.TfprofLog
+                     , Proto.Tensorflow.Core.Profiler.TfprofLog_Fields
+                     , Proto.Tensorflow.Core.Profiler.TfprofOptions
+                     , Proto.Tensorflow.Core.Profiler.TfprofOptions_Fields
+                     , Proto.Tensorflow.Core.Profiler.TfprofOutput
+                     , Proto.Tensorflow.Core.Profiler.TfprofOutput_Fields
+                     , Proto.Tensorflow.Core.Protobuf.Autotuning
+                     , Proto.Tensorflow.Core.Protobuf.Autotuning_Fields
+                     , Proto.Tensorflow.Core.Protobuf.BfcMemoryMap
+                     , Proto.Tensorflow.Core.Protobuf.BfcMemoryMap_Fields
                      , Proto.Tensorflow.Core.Protobuf.Cluster
                      , Proto.Tensorflow.Core.Protobuf.Cluster_Fields
+                     , Proto.Tensorflow.Core.Protobuf.CompositeTensorVariant
+                     , Proto.Tensorflow.Core.Protobuf.CompositeTensorVariant_Fields
                      , Proto.Tensorflow.Core.Protobuf.Config
                      , Proto.Tensorflow.Core.Protobuf.Config_Fields
                      , Proto.Tensorflow.Core.Protobuf.ControlFlow
                      , Proto.Tensorflow.Core.Protobuf.ControlFlow_Fields
+                     , Proto.Tensorflow.Core.Protobuf.ConvAutotuning
+                     , Proto.Tensorflow.Core.Protobuf.ConvAutotuning_Fields
+                     , Proto.Tensorflow.Core.Protobuf.CoordinationConfig
+                     , Proto.Tensorflow.Core.Protobuf.CoordinationConfig_Fields
+                     , Proto.Tensorflow.Core.Protobuf.CoordinationService
+                     , Proto.Tensorflow.Core.Protobuf.CoordinationService_Fields
+                     , Proto.Tensorflow.Core.Protobuf.CorePlatformPayloads
+                     , Proto.Tensorflow.Core.Protobuf.CorePlatformPayloads_Fields
+                     , Proto.Tensorflow.Core.Protobuf.CriticalSection
+                     , Proto.Tensorflow.Core.Protobuf.CriticalSection_Fields
+                     , Proto.Tensorflow.Core.Protobuf.DataService
+                     , Proto.Tensorflow.Core.Protobuf.DataService_Fields
                      , Proto.Tensorflow.Core.Protobuf.Debug
                      , Proto.Tensorflow.Core.Protobuf.Debug_Fields
+                     , Proto.Tensorflow.Core.Protobuf.DebugEvent
+                     , Proto.Tensorflow.Core.Protobuf.DebugEvent_Fields
                      , Proto.Tensorflow.Core.Protobuf.DeviceFilters
+                     , Proto.Tensorflow.Core.Protobuf.DeviceFilters_Fields
+                     , Proto.Tensorflow.Core.Protobuf.DeviceProperties
+                     , Proto.Tensorflow.Core.Protobuf.DeviceProperties_Fields
+                     , Proto.Tensorflow.Core.Protobuf.DistributedRuntimePayloads
+                     , Proto.Tensorflow.Core.Protobuf.DistributedRuntimePayloads_Fields
+                     , Proto.Tensorflow.Core.Protobuf.EagerService
+                     , Proto.Tensorflow.Core.Protobuf.EagerService_Fields
                      , Proto.Tensorflow.Core.Protobuf.ErrorCodes
+                     , Proto.Tensorflow.Core.Protobuf.ErrorCodes_Fields
+                     , Proto.Tensorflow.Core.Protobuf.Fingerprint
+                     , Proto.Tensorflow.Core.Protobuf.Fingerprint_Fields
+                     , Proto.Tensorflow.Core.Protobuf.GraphDebugInfo
+                     , Proto.Tensorflow.Core.Protobuf.GraphDebugInfo_Fields
+                     , Proto.Tensorflow.Core.Protobuf.Master
+                     , Proto.Tensorflow.Core.Protobuf.Master_Fields
+                     , Proto.Tensorflow.Core.Protobuf.MasterService
+                     , Proto.Tensorflow.Core.Protobuf.MasterService_Fields
                      , Proto.Tensorflow.Core.Protobuf.MetaGraph
                      , Proto.Tensorflow.Core.Protobuf.MetaGraph_Fields
                      , Proto.Tensorflow.Core.Protobuf.NamedTensor
                      , Proto.Tensorflow.Core.Protobuf.NamedTensor_Fields
                      , Proto.Tensorflow.Core.Protobuf.QueueRunner
                      , Proto.Tensorflow.Core.Protobuf.QueueRunner_Fields
+                     , Proto.Tensorflow.Core.Protobuf.RemoteTensorHandle
+                     , Proto.Tensorflow.Core.Protobuf.RemoteTensorHandle_Fields
+                     , Proto.Tensorflow.Core.Protobuf.ReplayLog
+                     , Proto.Tensorflow.Core.Protobuf.ReplayLog_Fields
                      , Proto.Tensorflow.Core.Protobuf.RewriterConfig
                      , Proto.Tensorflow.Core.Protobuf.RewriterConfig_Fields
                      , Proto.Tensorflow.Core.Protobuf.SavedModel
                      , Proto.Tensorflow.Core.Protobuf.SavedModel_Fields
                      , Proto.Tensorflow.Core.Protobuf.SavedObjectGraph
+                     , Proto.Tensorflow.Core.Protobuf.SavedObjectGraph_Fields
                      , Proto.Tensorflow.Core.Protobuf.Saver
                      , Proto.Tensorflow.Core.Protobuf.Saver_Fields
+                     , Proto.Tensorflow.Core.Protobuf.ServiceConfig
+                     , Proto.Tensorflow.Core.Protobuf.ServiceConfig_Fields
+                     , Proto.Tensorflow.Core.Protobuf.Snapshot
+                     , Proto.Tensorflow.Core.Protobuf.Snapshot_Fields
+                     , Proto.Tensorflow.Core.Protobuf.Status
+                     , Proto.Tensorflow.Core.Protobuf.Status_Fields
                      , Proto.Tensorflow.Core.Protobuf.Struct
+                     , Proto.Tensorflow.Core.Protobuf.Struct_Fields
                      , Proto.Tensorflow.Core.Protobuf.TensorBundle
                      , Proto.Tensorflow.Core.Protobuf.TensorBundle_Fields
                      , Proto.Tensorflow.Core.Protobuf.TensorflowServer
                      , Proto.Tensorflow.Core.Protobuf.TensorflowServer_Fields
+                     , Proto.Tensorflow.Core.Protobuf.Tpu.CompilationResult
+                     , Proto.Tensorflow.Core.Protobuf.Tpu.CompilationResult_Fields
+                     , Proto.Tensorflow.Core.Protobuf.Tpu.CompileMetadata
+                     , Proto.Tensorflow.Core.Protobuf.Tpu.CompileMetadata_Fields
+                     , Proto.Tensorflow.Core.Protobuf.Tpu.DynamicPadding
+                     , Proto.Tensorflow.Core.Protobuf.Tpu.DynamicPadding_Fields
+                     , Proto.Tensorflow.Core.Protobuf.Tpu.OptimizationParameters
+                     , Proto.Tensorflow.Core.Protobuf.Tpu.OptimizationParameters_Fields
+                     , Proto.Tensorflow.Core.Protobuf.Tpu.Topology
+                     , Proto.Tensorflow.Core.Protobuf.Tpu.Topology_Fields
+                     , Proto.Tensorflow.Core.Protobuf.Tpu.TpuEmbeddingConfiguration
+                     , Proto.Tensorflow.Core.Protobuf.Tpu.TpuEmbeddingConfiguration_Fields
                      , Proto.Tensorflow.Core.Protobuf.TrackableObjectGraph
+                     , Proto.Tensorflow.Core.Protobuf.TrackableObjectGraph_Fields
+                     , Proto.Tensorflow.Core.Protobuf.TransportOptions
+                     , Proto.Tensorflow.Core.Protobuf.TransportOptions_Fields
                      , Proto.Tensorflow.Core.Protobuf.VerifierConfig
+                     , Proto.Tensorflow.Core.Protobuf.VerifierConfig_Fields
+                     , Proto.Tensorflow.Core.Protobuf.Worker
+                     , Proto.Tensorflow.Core.Protobuf.Worker_Fields
+                     , Proto.Tensorflow.Core.Protobuf.WorkerService
+                     , Proto.Tensorflow.Core.Protobuf.WorkerService_Fields
+                     , Proto.Tensorflow.Core.Tfrt.Fallback.OpCostMap
+                     , Proto.Tensorflow.Core.Tfrt.Fallback.OpCostMap_Fields
+                     , Proto.Tensorflow.Core.Tpu.Kernels.TpuCompilationCache
+                     , Proto.Tensorflow.Core.Tpu.Kernels.TpuCompilationCache_Fields
+                     , Proto.Tensorflow.Core.Tpu.Kernels.TpuCompilationCacheCommon
+                     , Proto.Tensorflow.Core.Tpu.Kernels.TpuCompilationCacheCommon_Fields
+                     , Proto.Tensorflow.Core.Tpu.Kernels.TpuCompile
+                     , Proto.Tensorflow.Core.Tpu.Kernels.TpuCompile_Fields
+                     , Proto.Tensorflow.Core.Tpu.Kernels.TpuExecutableInfo
+                     , Proto.Tensorflow.Core.Tpu.Kernels.TpuExecutableInfo_Fields
+                     , Proto.Tensorflow.Core.Util.AutotuneMaps.AutotuneMap
+                     , Proto.Tensorflow.Core.Util.AutotuneMaps.AutotuneMap_Fields
+                     , Proto.Tensorflow.Core.Util.AutotuneMaps.ConvParameters
+                     , Proto.Tensorflow.Core.Util.AutotuneMaps.ConvParameters_Fields
                      , Proto.Tensorflow.Core.Util.Event
                      , Proto.Tensorflow.Core.Util.Event_Fields
+                     , Proto.Tensorflow.Core.Util.ExampleProtoFastParsingTest
+                     , Proto.Tensorflow.Core.Util.ExampleProtoFastParsingTest_Fields
                      , Proto.Tensorflow.Core.Util.MemmappedFileSystem
                      , Proto.Tensorflow.Core.Util.MemmappedFileSystem_Fields
                      , Proto.Tensorflow.Core.Util.SavedTensorSlice
                      , Proto.Tensorflow.Core.Util.SavedTensorSlice_Fields
                      , Proto.Tensorflow.Core.Util.TestLog
                      , Proto.Tensorflow.Core.Util.TestLog_Fields
-  autogen-modules:     Proto.Tensorflow.Core.Example.Example
+                     , Proto.Tensorflow.Distribute.Experimental.Rpc.Proto.TfRpcService
+                     , Proto.Tensorflow.Distribute.Experimental.Rpc.Proto.TfRpcService_Fields
+                     , Proto.Tensorflow.Dtensor.Proto.Layout
+                     , Proto.Tensorflow.Dtensor.Proto.Layout_Fields
+                     , Proto.Tensorflow.Lite.Experimental.Acceleration.Configuration.Configuration
+                     , Proto.Tensorflow.Lite.Experimental.Acceleration.Configuration.Configuration_Fields
+                     , Proto.Tensorflow.Lite.Python.Metrics.ConverterErrorData
+                     , Proto.Tensorflow.Lite.Python.Metrics.ConverterErrorData_Fields
+                     , Proto.Tensorflow.Lite.Toco.Logging.TocoConversionLog
+                     , Proto.Tensorflow.Lite.Toco.Logging.TocoConversionLog_Fields
+                     , Proto.Tensorflow.Lite.Toco.ModelFlags
+                     , Proto.Tensorflow.Lite.Toco.ModelFlags_Fields
+                     , Proto.Tensorflow.Lite.Toco.TocoFlags
+                     , Proto.Tensorflow.Lite.Toco.TocoFlags_Fields
+                     , Proto.Tensorflow.Lite.Toco.Types
+                     , Proto.Tensorflow.Lite.Toco.Types_Fields
+                     , Proto.Tensorflow.Lite.Tools.Evaluation.Proto.EvaluationConfig
+                     , Proto.Tensorflow.Lite.Tools.Evaluation.Proto.EvaluationConfig_Fields
+                     , Proto.Tensorflow.Lite.Tools.Evaluation.Proto.EvaluationStages
+                     , Proto.Tensorflow.Lite.Tools.Evaluation.Proto.EvaluationStages_Fields
+                     , Proto.Tensorflow.Lite.Tools.Evaluation.Proto.PreprocessingSteps
+                     , Proto.Tensorflow.Lite.Tools.Evaluation.Proto.PreprocessingSteps_Fields
+                     , Proto.Tensorflow.Python.Framework.CppShapeInference
+                     , Proto.Tensorflow.Python.Framework.CppShapeInference_Fields
+                     , Proto.Tensorflow.Python.Keras.Protobuf.ProjectorConfig
+                     , Proto.Tensorflow.Python.Keras.Protobuf.ProjectorConfig_Fields
+                     , Proto.Tensorflow.Python.Keras.Protobuf.SavedMetadata
+                     , Proto.Tensorflow.Python.Keras.Protobuf.SavedMetadata_Fields
+                     , Proto.Tensorflow.Python.Keras.Protobuf.Versions
+                     , Proto.Tensorflow.Python.Keras.Protobuf.Versions_Fields
+                     , Proto.Tensorflow.Python.KernelTests.Proto.TestExample
+                     , Proto.Tensorflow.Python.KernelTests.Proto.TestExample_Fields
+                     , Proto.Tensorflow.Python.Tpu.TensorTracer
+                     , Proto.Tensorflow.Python.Tpu.TensorTracer_Fields
+                     , Proto.Tensorflow.Python.Training.CheckpointState
+                     , Proto.Tensorflow.Python.Training.CheckpointState_Fields
+                     , Proto.Tensorflow.Python.Util.Protobuf.CompareTest
+                     , Proto.Tensorflow.Python.Util.Protobuf.CompareTest_Fields
+                     , Proto.Tensorflow.Security.Fuzzing.CheckpointReaderFuzzInput
+                     , Proto.Tensorflow.Security.Fuzzing.CheckpointReaderFuzzInput_Fields
+                     , Proto.Tensorflow.StreamExecutor.Dnn
+                     , Proto.Tensorflow.StreamExecutor.Dnn_Fields
+                     , Proto.Tensorflow.Tools.Api.Lib.ApiObjects
+                     , Proto.Tensorflow.Tools.Api.Lib.ApiObjects_Fields
+                     , Proto.Tensorflow.Tools.ProtoText.Test
+                     , Proto.Tensorflow.Tools.ProtoText.Test_Fields
+  autogen-modules:     Proto.Tensorflow.Compiler.Jit.XlaActivity
+                     , Proto.Tensorflow.Compiler.Jit.XlaActivity_Fields
+                     , Proto.Tensorflow.Compiler.Jit.XlaCompilationCache
+                     , Proto.Tensorflow.Compiler.Jit.XlaCompilationCache_Fields
+                     , Proto.Tensorflow.Compiler.Mlir.Lite.Quantization.QuantizationInfo
+                     , Proto.Tensorflow.Compiler.Mlir.Lite.Quantization.QuantizationInfo_Fields
+                     , Proto.Tensorflow.Compiler.Mlir.Quantization.Tensorflow.QuantizationOptions
+                     , Proto.Tensorflow.Compiler.Mlir.Quantization.Tensorflow.QuantizationOptions_Fields
+                     , Proto.Tensorflow.Compiler.Mlir.Tfrt.Analysis.Analysis
+                     , Proto.Tensorflow.Compiler.Mlir.Tfrt.Analysis.Analysis_Fields
+                     , Proto.Tensorflow.Compiler.Mlir.Tools.KernelGen.CompileCacheItem
+                     , Proto.Tensorflow.Compiler.Mlir.Tools.KernelGen.CompileCacheItem_Fields
+                     , Proto.Tensorflow.Compiler.Tf2tensorrt.Utils.TrtEngineInstance
+                     , Proto.Tensorflow.Compiler.Tf2tensorrt.Utils.TrtEngineInstance_Fields
+                     , Proto.Tensorflow.Compiler.Tf2xla.HostComputeMetadata
+                     , Proto.Tensorflow.Compiler.Tf2xla.HostComputeMetadata_Fields
+                     , Proto.Tensorflow.Compiler.Tf2xla.Kernels.Callback
+                     , Proto.Tensorflow.Compiler.Tf2xla.Kernels.Callback_Fields
+                     , Proto.Tensorflow.Compiler.Tf2xla.Support
+                     , Proto.Tensorflow.Compiler.Tf2xla.Support_Fields
+                     , Proto.Tensorflow.Compiler.Tf2xla.Tf2xla
+                     , Proto.Tensorflow.Compiler.Tf2xla.Tf2xla_Fields
+                     , Proto.Tensorflow.Compiler.Xla.Pjrt.Distributed.Protocol
+                     , Proto.Tensorflow.Compiler.Xla.Pjrt.Distributed.Protocol_Fields
+                     , Proto.Tensorflow.Compiler.Xla.Python.TpuDriver.TpuDriver
+                     , Proto.Tensorflow.Compiler.Xla.Python.TpuDriver.TpuDriver_Fields
+                     , Proto.Tensorflow.Compiler.Xla.Python.TpuDriver.TpuService
+                     , Proto.Tensorflow.Compiler.Xla.Python.TpuDriver.TpuService_Fields
+                     , Proto.Tensorflow.Compiler.Xla.Rpc.XlaService
+                     , Proto.Tensorflow.Compiler.Xla.Rpc.XlaService_Fields
+                     , Proto.Tensorflow.Compiler.Xla.Service.Gpu.BackendConfigs
+                     , Proto.Tensorflow.Compiler.Xla.Service.Gpu.BackendConfigs_Fields
+                     , Proto.Tensorflow.Compiler.Xla.Service.Gpu.GpuAutotuning
+                     , Proto.Tensorflow.Compiler.Xla.Service.Gpu.GpuAutotuning_Fields
+                     , Proto.Tensorflow.Compiler.Xla.Service.Hlo
+                     , Proto.Tensorflow.Compiler.Xla.Service.Hlo_Fields
+                     , Proto.Tensorflow.Compiler.Xla.Service.HloExecutionProfileData
+                     , Proto.Tensorflow.Compiler.Xla.Service.HloExecutionProfileData_Fields
+                     , Proto.Tensorflow.Compiler.Xla.Service.HloProfilePrinterData
+                     , Proto.Tensorflow.Compiler.Xla.Service.HloProfilePrinterData_Fields
+                     , Proto.Tensorflow.Compiler.Xla.Service.TestCompilationEnvironment
+                     , Proto.Tensorflow.Compiler.Xla.Service.TestCompilationEnvironment_Fields
+                     , Proto.Tensorflow.Compiler.Xla.Tools.RunHloModule
+                     , Proto.Tensorflow.Compiler.Xla.Tools.RunHloModule_Fields
+                     , Proto.Tensorflow.Compiler.Xla.Xla
+                     , Proto.Tensorflow.Compiler.Xla.Xla_Fields
+                     , Proto.Tensorflow.Compiler.Xla.XlaData
+                     , Proto.Tensorflow.Compiler.Xla.XlaData_Fields
+                     , Proto.Tensorflow.Compiler.Xrt.Xrt
+                     , Proto.Tensorflow.Compiler.Xrt.Xrt_Fields
+                     , Proto.Tensorflow.Core.Data.Dataset
+                     , Proto.Tensorflow.Core.Data.Dataset_Fields
+                     , Proto.Tensorflow.Core.Data.Service.Common
+                     , Proto.Tensorflow.Core.Data.Service.Common_Fields
+                     , Proto.Tensorflow.Core.Data.Service.Dispatcher
+                     , Proto.Tensorflow.Core.Data.Service.Dispatcher_Fields
+                     , Proto.Tensorflow.Core.Data.Service.Export
+                     , Proto.Tensorflow.Core.Data.Service.Export_Fields
+                     , Proto.Tensorflow.Core.Data.Service.Journal
+                     , Proto.Tensorflow.Core.Data.Service.Journal_Fields
+                     , Proto.Tensorflow.Core.Data.Service.Worker
+                     , Proto.Tensorflow.Core.Data.Service.Worker_Fields
+                     , Proto.Tensorflow.Core.Debug.DebugService
+                     , Proto.Tensorflow.Core.Debug.DebugService_Fields
+                     , Proto.Tensorflow.Core.Debug.DebuggerEventMetadata
+                     , Proto.Tensorflow.Core.Debug.DebuggerEventMetadata_Fields
+                     , Proto.Tensorflow.Core.Example.Example
                      , Proto.Tensorflow.Core.Example.Example_Fields
                      , Proto.Tensorflow.Core.Example.ExampleParserConfiguration
                      , Proto.Tensorflow.Core.Example.ExampleParserConfiguration_Fields
@@ -111,27 +498,40 @@ library
                      , Proto.Tensorflow.Core.Example.Feature_Fields
                      , Proto.Tensorflow.Core.Framework.AllocationDescription
                      , Proto.Tensorflow.Core.Framework.AllocationDescription_Fields
+                     , Proto.Tensorflow.Core.Framework.ApiDef
+                     , Proto.Tensorflow.Core.Framework.ApiDef_Fields
                      , Proto.Tensorflow.Core.Framework.AttrValue
                      , Proto.Tensorflow.Core.Framework.AttrValue_Fields
                      , Proto.Tensorflow.Core.Framework.CostGraph
                      , Proto.Tensorflow.Core.Framework.CostGraph_Fields
+                     , Proto.Tensorflow.Core.Framework.DatasetMetadata
+                     , Proto.Tensorflow.Core.Framework.DatasetMetadata_Fields
+                     , Proto.Tensorflow.Core.Framework.DatasetOptions
+                     , Proto.Tensorflow.Core.Framework.DatasetOptions_Fields
                      , Proto.Tensorflow.Core.Framework.DeviceAttributes
                      , Proto.Tensorflow.Core.Framework.DeviceAttributes_Fields
+                     , Proto.Tensorflow.Core.Framework.FullType
+                     , Proto.Tensorflow.Core.Framework.FullType_Fields
                      , Proto.Tensorflow.Core.Framework.Function
                      , Proto.Tensorflow.Core.Framework.Function_Fields
                      , Proto.Tensorflow.Core.Framework.Graph
                      , Proto.Tensorflow.Core.Framework.Graph_Fields
+                     , Proto.Tensorflow.Core.Framework.GraphTransferInfo
+                     , Proto.Tensorflow.Core.Framework.GraphTransferInfo_Fields
                      , Proto.Tensorflow.Core.Framework.KernelDef
                      , Proto.Tensorflow.Core.Framework.KernelDef_Fields
                      , Proto.Tensorflow.Core.Framework.LogMemory
                      , Proto.Tensorflow.Core.Framework.LogMemory_Fields
+                     , Proto.Tensorflow.Core.Framework.Model
+                     , Proto.Tensorflow.Core.Framework.Model_Fields
                      , Proto.Tensorflow.Core.Framework.NodeDef
                      , Proto.Tensorflow.Core.Framework.NodeDef_Fields
                      , Proto.Tensorflow.Core.Framework.OpDef
                      , Proto.Tensorflow.Core.Framework.OpDef_Fields
+                     , Proto.Tensorflow.Core.Framework.ReaderBase
+                     , Proto.Tensorflow.Core.Framework.ReaderBase_Fields
                      , Proto.Tensorflow.Core.Framework.ResourceHandle
                      , Proto.Tensorflow.Core.Framework.ResourceHandle_Fields
-                     , Proto.Tensorflow.Core.Protobuf.SavedObjectGraph
                      , Proto.Tensorflow.Core.Framework.StepStats
                      , Proto.Tensorflow.Core.Framework.StepStats_Fields
                      , Proto.Tensorflow.Core.Framework.Summary
@@ -150,45 +550,240 @@ library
                      , Proto.Tensorflow.Core.Framework.Variable_Fields
                      , Proto.Tensorflow.Core.Framework.Versions
                      , Proto.Tensorflow.Core.Framework.Versions_Fields
+                     , Proto.Tensorflow.Core.Function.TraceType.DefaultTypes
+                     , Proto.Tensorflow.Core.Function.TraceType.DefaultTypes_Fields
+                     , Proto.Tensorflow.Core.Function.TraceType.Serialization
+                     , Proto.Tensorflow.Core.Function.TraceType.Serialization_Fields
+                     , Proto.Tensorflow.Core.Function.TraceType.SerializationTest
+                     , Proto.Tensorflow.Core.Function.TraceType.SerializationTest_Fields
+                     , Proto.Tensorflow.Core.Grappler.Costs.OpPerformanceData
+                     , Proto.Tensorflow.Core.Grappler.Costs.OpPerformanceData_Fields
+                     , Proto.Tensorflow.Core.Grappler.Optimizers.Inference.BatchOpRewriter
+                     , Proto.Tensorflow.Core.Grappler.Optimizers.Inference.BatchOpRewriter_Fields
                      , Proto.Tensorflow.Core.Lib.Core.ErrorCodes
+                     , Proto.Tensorflow.Core.Lib.Core.ErrorCodes_Fields
+                     , Proto.Tensorflow.Core.Profiler.Profile
+                     , Proto.Tensorflow.Core.Profiler.Profile_Fields
+                     , Proto.Tensorflow.Core.Profiler.ProfilerAnalysis
+                     , Proto.Tensorflow.Core.Profiler.ProfilerAnalysis_Fields
+                     , Proto.Tensorflow.Core.Profiler.ProfilerOptions
+                     , Proto.Tensorflow.Core.Profiler.ProfilerOptions_Fields
+                     , Proto.Tensorflow.Core.Profiler.ProfilerService
+                     , Proto.Tensorflow.Core.Profiler.ProfilerService_Fields
+                     , Proto.Tensorflow.Core.Profiler.ProfilerServiceMonitorResult
+                     , Proto.Tensorflow.Core.Profiler.ProfilerServiceMonitorResult_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.Diagnostics
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.Diagnostics_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.HardwareTypes
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.HardwareTypes_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.InputPipeline
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.InputPipeline_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.KernelStats
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.KernelStats_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.MemoryProfile
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.MemoryProfile_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.MemoryViewerPreprocess
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.MemoryViewerPreprocess_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.OpMetrics
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.OpMetrics_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.OpProfile
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.OpProfile_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.OpStats
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.OpStats_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.OverviewPage
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.OverviewPage_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.PodStats
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.PodStats_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.PodViewer
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.PodViewer_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.StepsDb
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.StepsDb_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.TfDataStats
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.TfDataStats_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.TfFunction
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.TfFunction_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.TfStats
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.TfStats_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.Tfstreamz
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.Tfstreamz_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.TraceEvents
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.TraceEvents_Fields
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.Xplane
+                     , Proto.Tensorflow.Core.Profiler.Protobuf.Xplane_Fields
+                     , Proto.Tensorflow.Core.Profiler.TfprofLog
+                     , Proto.Tensorflow.Core.Profiler.TfprofLog_Fields
+                     , Proto.Tensorflow.Core.Profiler.TfprofOptions
+                     , Proto.Tensorflow.Core.Profiler.TfprofOptions_Fields
+                     , Proto.Tensorflow.Core.Profiler.TfprofOutput
+                     , Proto.Tensorflow.Core.Profiler.TfprofOutput_Fields
+                     , Proto.Tensorflow.Core.Protobuf.Autotuning
+                     , Proto.Tensorflow.Core.Protobuf.Autotuning_Fields
+                     , Proto.Tensorflow.Core.Protobuf.BfcMemoryMap
+                     , Proto.Tensorflow.Core.Protobuf.BfcMemoryMap_Fields
                      , Proto.Tensorflow.Core.Protobuf.Cluster
                      , Proto.Tensorflow.Core.Protobuf.Cluster_Fields
+                     , Proto.Tensorflow.Core.Protobuf.CompositeTensorVariant
+                     , Proto.Tensorflow.Core.Protobuf.CompositeTensorVariant_Fields
                      , Proto.Tensorflow.Core.Protobuf.Config
                      , Proto.Tensorflow.Core.Protobuf.Config_Fields
                      , Proto.Tensorflow.Core.Protobuf.ControlFlow
                      , Proto.Tensorflow.Core.Protobuf.ControlFlow_Fields
+                     , Proto.Tensorflow.Core.Protobuf.ConvAutotuning
+                     , Proto.Tensorflow.Core.Protobuf.ConvAutotuning_Fields
+                     , Proto.Tensorflow.Core.Protobuf.CoordinationConfig
+                     , Proto.Tensorflow.Core.Protobuf.CoordinationConfig_Fields
+                     , Proto.Tensorflow.Core.Protobuf.CoordinationService
+                     , Proto.Tensorflow.Core.Protobuf.CoordinationService_Fields
+                     , Proto.Tensorflow.Core.Protobuf.CorePlatformPayloads
+                     , Proto.Tensorflow.Core.Protobuf.CorePlatformPayloads_Fields
+                     , Proto.Tensorflow.Core.Protobuf.CriticalSection
+                     , Proto.Tensorflow.Core.Protobuf.CriticalSection_Fields
+                     , Proto.Tensorflow.Core.Protobuf.DataService
+                     , Proto.Tensorflow.Core.Protobuf.DataService_Fields
                      , Proto.Tensorflow.Core.Protobuf.Debug
                      , Proto.Tensorflow.Core.Protobuf.Debug_Fields
+                     , Proto.Tensorflow.Core.Protobuf.DebugEvent
+                     , Proto.Tensorflow.Core.Protobuf.DebugEvent_Fields
                      , Proto.Tensorflow.Core.Protobuf.DeviceFilters
+                     , Proto.Tensorflow.Core.Protobuf.DeviceFilters_Fields
+                     , Proto.Tensorflow.Core.Protobuf.DeviceProperties
+                     , Proto.Tensorflow.Core.Protobuf.DeviceProperties_Fields
+                     , Proto.Tensorflow.Core.Protobuf.DistributedRuntimePayloads
+                     , Proto.Tensorflow.Core.Protobuf.DistributedRuntimePayloads_Fields
+                     , Proto.Tensorflow.Core.Protobuf.EagerService
+                     , Proto.Tensorflow.Core.Protobuf.EagerService_Fields
                      , Proto.Tensorflow.Core.Protobuf.ErrorCodes
+                     , Proto.Tensorflow.Core.Protobuf.ErrorCodes_Fields
+                     , Proto.Tensorflow.Core.Protobuf.Fingerprint
+                     , Proto.Tensorflow.Core.Protobuf.Fingerprint_Fields
+                     , Proto.Tensorflow.Core.Protobuf.GraphDebugInfo
+                     , Proto.Tensorflow.Core.Protobuf.GraphDebugInfo_Fields
+                     , Proto.Tensorflow.Core.Protobuf.Master
+                     , Proto.Tensorflow.Core.Protobuf.Master_Fields
+                     , Proto.Tensorflow.Core.Protobuf.MasterService
+                     , Proto.Tensorflow.Core.Protobuf.MasterService_Fields
                      , Proto.Tensorflow.Core.Protobuf.MetaGraph
                      , Proto.Tensorflow.Core.Protobuf.MetaGraph_Fields
                      , Proto.Tensorflow.Core.Protobuf.NamedTensor
                      , Proto.Tensorflow.Core.Protobuf.NamedTensor_Fields
                      , Proto.Tensorflow.Core.Protobuf.QueueRunner
                      , Proto.Tensorflow.Core.Protobuf.QueueRunner_Fields
+                     , Proto.Tensorflow.Core.Protobuf.RemoteTensorHandle
+                     , Proto.Tensorflow.Core.Protobuf.RemoteTensorHandle_Fields
+                     , Proto.Tensorflow.Core.Protobuf.ReplayLog
+                     , Proto.Tensorflow.Core.Protobuf.ReplayLog_Fields
                      , Proto.Tensorflow.Core.Protobuf.RewriterConfig
                      , Proto.Tensorflow.Core.Protobuf.RewriterConfig_Fields
                      , Proto.Tensorflow.Core.Protobuf.SavedModel
                      , Proto.Tensorflow.Core.Protobuf.SavedModel_Fields
                      , Proto.Tensorflow.Core.Protobuf.SavedObjectGraph
+                     , Proto.Tensorflow.Core.Protobuf.SavedObjectGraph_Fields
                      , Proto.Tensorflow.Core.Protobuf.Saver
                      , Proto.Tensorflow.Core.Protobuf.Saver_Fields
+                     , Proto.Tensorflow.Core.Protobuf.ServiceConfig
+                     , Proto.Tensorflow.Core.Protobuf.ServiceConfig_Fields
+                     , Proto.Tensorflow.Core.Protobuf.Snapshot
+                     , Proto.Tensorflow.Core.Protobuf.Snapshot_Fields
+                     , Proto.Tensorflow.Core.Protobuf.Status
+                     , Proto.Tensorflow.Core.Protobuf.Status_Fields
                      , Proto.Tensorflow.Core.Protobuf.Struct
+                     , Proto.Tensorflow.Core.Protobuf.Struct_Fields
                      , Proto.Tensorflow.Core.Protobuf.TensorBundle
                      , Proto.Tensorflow.Core.Protobuf.TensorBundle_Fields
                      , Proto.Tensorflow.Core.Protobuf.TensorflowServer
                      , Proto.Tensorflow.Core.Protobuf.TensorflowServer_Fields
+                     , Proto.Tensorflow.Core.Protobuf.Tpu.CompilationResult
+                     , Proto.Tensorflow.Core.Protobuf.Tpu.CompilationResult_Fields
+                     , Proto.Tensorflow.Core.Protobuf.Tpu.CompileMetadata
+                     , Proto.Tensorflow.Core.Protobuf.Tpu.CompileMetadata_Fields
+                     , Proto.Tensorflow.Core.Protobuf.Tpu.DynamicPadding
+                     , Proto.Tensorflow.Core.Protobuf.Tpu.DynamicPadding_Fields
+                     , Proto.Tensorflow.Core.Protobuf.Tpu.OptimizationParameters
+                     , Proto.Tensorflow.Core.Protobuf.Tpu.OptimizationParameters_Fields
+                     , Proto.Tensorflow.Core.Protobuf.Tpu.Topology
+                     , Proto.Tensorflow.Core.Protobuf.Tpu.Topology_Fields
+                     , Proto.Tensorflow.Core.Protobuf.Tpu.TpuEmbeddingConfiguration
+                     , Proto.Tensorflow.Core.Protobuf.Tpu.TpuEmbeddingConfiguration_Fields
                      , Proto.Tensorflow.Core.Protobuf.TrackableObjectGraph
+                     , Proto.Tensorflow.Core.Protobuf.TrackableObjectGraph_Fields
+                     , Proto.Tensorflow.Core.Protobuf.TransportOptions
+                     , Proto.Tensorflow.Core.Protobuf.TransportOptions_Fields
                      , Proto.Tensorflow.Core.Protobuf.VerifierConfig
+                     , Proto.Tensorflow.Core.Protobuf.VerifierConfig_Fields
+                     , Proto.Tensorflow.Core.Protobuf.Worker
+                     , Proto.Tensorflow.Core.Protobuf.Worker_Fields
+                     , Proto.Tensorflow.Core.Protobuf.WorkerService
+                     , Proto.Tensorflow.Core.Protobuf.WorkerService_Fields
+                     , Proto.Tensorflow.Core.Tfrt.Fallback.OpCostMap
+                     , Proto.Tensorflow.Core.Tfrt.Fallback.OpCostMap_Fields
+                     , Proto.Tensorflow.Core.Tpu.Kernels.TpuCompilationCache
+                     , Proto.Tensorflow.Core.Tpu.Kernels.TpuCompilationCache_Fields
+                     , Proto.Tensorflow.Core.Tpu.Kernels.TpuCompilationCacheCommon
+                     , Proto.Tensorflow.Core.Tpu.Kernels.TpuCompilationCacheCommon_Fields
+                     , Proto.Tensorflow.Core.Tpu.Kernels.TpuCompile
+                     , Proto.Tensorflow.Core.Tpu.Kernels.TpuCompile_Fields
+                     , Proto.Tensorflow.Core.Tpu.Kernels.TpuExecutableInfo
+                     , Proto.Tensorflow.Core.Tpu.Kernels.TpuExecutableInfo_Fields
+                     , Proto.Tensorflow.Core.Util.AutotuneMaps.AutotuneMap
+                     , Proto.Tensorflow.Core.Util.AutotuneMaps.AutotuneMap_Fields
+                     , Proto.Tensorflow.Core.Util.AutotuneMaps.ConvParameters
+                     , Proto.Tensorflow.Core.Util.AutotuneMaps.ConvParameters_Fields
                      , Proto.Tensorflow.Core.Util.Event
                      , Proto.Tensorflow.Core.Util.Event_Fields
+                     , Proto.Tensorflow.Core.Util.ExampleProtoFastParsingTest
+                     , Proto.Tensorflow.Core.Util.ExampleProtoFastParsingTest_Fields
                      , Proto.Tensorflow.Core.Util.MemmappedFileSystem
                      , Proto.Tensorflow.Core.Util.MemmappedFileSystem_Fields
                      , Proto.Tensorflow.Core.Util.SavedTensorSlice
                      , Proto.Tensorflow.Core.Util.SavedTensorSlice_Fields
                      , Proto.Tensorflow.Core.Util.TestLog
                      , Proto.Tensorflow.Core.Util.TestLog_Fields
+                     , Proto.Tensorflow.Distribute.Experimental.Rpc.Proto.TfRpcService
+                     , Proto.Tensorflow.Distribute.Experimental.Rpc.Proto.TfRpcService_Fields
+                     , Proto.Tensorflow.Dtensor.Proto.Layout
+                     , Proto.Tensorflow.Dtensor.Proto.Layout_Fields
+                     , Proto.Tensorflow.Lite.Experimental.Acceleration.Configuration.Configuration
+                     , Proto.Tensorflow.Lite.Experimental.Acceleration.Configuration.Configuration_Fields
+                     , Proto.Tensorflow.Lite.Python.Metrics.ConverterErrorData
+                     , Proto.Tensorflow.Lite.Python.Metrics.ConverterErrorData_Fields
+                     , Proto.Tensorflow.Lite.Toco.Logging.TocoConversionLog
+                     , Proto.Tensorflow.Lite.Toco.Logging.TocoConversionLog_Fields
+                     , Proto.Tensorflow.Lite.Toco.ModelFlags
+                     , Proto.Tensorflow.Lite.Toco.ModelFlags_Fields
+                     , Proto.Tensorflow.Lite.Toco.TocoFlags
+                     , Proto.Tensorflow.Lite.Toco.TocoFlags_Fields
+                     , Proto.Tensorflow.Lite.Toco.Types
+                     , Proto.Tensorflow.Lite.Toco.Types_Fields
+                     , Proto.Tensorflow.Lite.Tools.Evaluation.Proto.EvaluationConfig
+                     , Proto.Tensorflow.Lite.Tools.Evaluation.Proto.EvaluationConfig_Fields
+                     , Proto.Tensorflow.Lite.Tools.Evaluation.Proto.EvaluationStages
+                     , Proto.Tensorflow.Lite.Tools.Evaluation.Proto.EvaluationStages_Fields
+                     , Proto.Tensorflow.Lite.Tools.Evaluation.Proto.PreprocessingSteps
+                     , Proto.Tensorflow.Lite.Tools.Evaluation.Proto.PreprocessingSteps_Fields
+                     , Proto.Tensorflow.Python.Framework.CppShapeInference
+                     , Proto.Tensorflow.Python.Framework.CppShapeInference_Fields
+                     , Proto.Tensorflow.Python.Keras.Protobuf.ProjectorConfig
+                     , Proto.Tensorflow.Python.Keras.Protobuf.ProjectorConfig_Fields
+                     , Proto.Tensorflow.Python.Keras.Protobuf.SavedMetadata
+                     , Proto.Tensorflow.Python.Keras.Protobuf.SavedMetadata_Fields
+                     , Proto.Tensorflow.Python.Keras.Protobuf.Versions
+                     , Proto.Tensorflow.Python.Keras.Protobuf.Versions_Fields
+                     , Proto.Tensorflow.Python.KernelTests.Proto.TestExample
+                     , Proto.Tensorflow.Python.KernelTests.Proto.TestExample_Fields
+                     , Proto.Tensorflow.Python.Tpu.TensorTracer
+                     , Proto.Tensorflow.Python.Tpu.TensorTracer_Fields
+                     , Proto.Tensorflow.Python.Training.CheckpointState
+                     , Proto.Tensorflow.Python.Training.CheckpointState_Fields
+                     , Proto.Tensorflow.Python.Util.Protobuf.CompareTest
+                     , Proto.Tensorflow.Python.Util.Protobuf.CompareTest_Fields
+                     , Proto.Tensorflow.Security.Fuzzing.CheckpointReaderFuzzInput
+                     , Proto.Tensorflow.Security.Fuzzing.CheckpointReaderFuzzInput_Fields
+                     , Proto.Tensorflow.StreamExecutor.Dnn
+                     , Proto.Tensorflow.StreamExecutor.Dnn_Fields
+                     , Proto.Tensorflow.Tools.Api.Lib.ApiObjects
+                     , Proto.Tensorflow.Tools.Api.Lib.ApiObjects_Fields
+                     , Proto.Tensorflow.Tools.ProtoText.Test
+                     , Proto.Tensorflow.Tools.ProtoText.Test_Fields
   build-depends:  proto-lens == 0.7.*
                 , proto-lens-runtime == 0.7.*
                 , proto-lens-protobuf-types == 0.7.*

--- a/tensorflow-proto/tensorflow-proto.cabal
+++ b/tensorflow-proto/tensorflow-proto.cabal
@@ -10,7 +10,7 @@ maintainer:          tensorflow-haskell@googlegroups.com
 copyright:           Google Inc.
 category:            Machine Learning
 build-type:          Custom
-cabal-version:       >=1.24
+cabal-version:       2.0
 extra-source-files:  third_party/tensorflow/tensorflow/core/example/*.proto
                    , third_party/tensorflow/tensorflow/core/framework/*.proto
                    , third_party/tensorflow/tensorflow/core/lib/core/error_codes.proto

--- a/tensorflow-records-conduit/tensorflow-records-conduit.cabal
+++ b/tensorflow-records-conduit/tensorflow-records-conduit.cabal
@@ -10,7 +10,7 @@ maintainer:          tensorflow-haskell@googlegroups.com
 copyright:           Google Inc.
 category:            Machine Learning
 build-type:          Simple
-cabal-version:       >=1.22
+cabal-version:       2.0
 
 library
   hs-source-dirs:   src

--- a/tensorflow-records/tensorflow-records.cabal
+++ b/tensorflow-records/tensorflow-records.cabal
@@ -10,7 +10,7 @@ maintainer:          tensorflow-haskell@googlegroups.com
 copyright:           Google Inc.
 category:            Machine Learning
 build-type:          Simple
-cabal-version:       >=1.22
+cabal-version:       2.0
 
 library
   hs-source-dirs:   src

--- a/tensorflow-test/tensorflow-test.cabal
+++ b/tensorflow-test/tensorflow-test.cabal
@@ -11,7 +11,7 @@ maintainer:          tensorflow-haskell@googlegroups.com
 copyright:           Google Inc.
 category:            Machine Learning
 build-type:          Simple
-cabal-version:       >=1.22
+cabal-version:       2.0
 
 library
   hs-source-dirs:   src

--- a/tensorflow/src/TensorFlow/Internal/Raw.chs
+++ b/tensorflow/src/TensorFlow/Internal/Raw.chs
@@ -44,6 +44,23 @@ message :: Status -> IO CString
 message = {# call TF_Message as ^ #}
 
 
+-- TString.
+{# pointer *TF_TString as TString newtype #}
+
+sizeOfTString :: Int
+sizeOfTString = 24
+
+-- TF_TString_Type::TF_TSTR_OFFSET
+tstringOffsetTypeTag :: Word32
+tstringOffsetTypeTag = 2
+
+stringGetDataPointer :: TString -> IO CString
+stringGetDataPointer = {# call TF_StringGetDataPointer as ^ #}
+
+stringGetSize :: TString -> IO CULong
+stringGetSize = {# call TF_StringGetSize as ^ #}
+
+
 -- Buffer.
 data Buffer
 {# pointer *TF_Buffer as BufferPtr -> Buffer #}

--- a/tensorflow/src/TensorFlow/Internal/Raw.chs
+++ b/tensorflow/src/TensorFlow/Internal/Raw.chs
@@ -21,12 +21,12 @@ module TensorFlow.Internal.Raw where
 import Foreign
 import Foreign.C
 
-{#enum TF_DataType as DataType {} deriving (Show, Eq) #}
-{#enum TF_Code as Code {} deriving (Show, Eq) #}
+{# enum TF_DataType as DataType {} deriving (Show, Eq) #}
+{# enum TF_Code as Code {} deriving (Show, Eq) #}
 
 
 -- Status.
-{#pointer *TF_Status as Status newtype #}
+{# pointer *TF_Status as Status newtype #}
 
 newStatus :: IO Status
 newStatus = {# call TF_NewStatus as ^ #}
@@ -46,16 +46,16 @@ message = {# call TF_Message as ^ #}
 
 -- Buffer.
 data Buffer
-{#pointer *TF_Buffer as BufferPtr -> Buffer #}
+{# pointer *TF_Buffer as BufferPtr -> Buffer #}
 
 getBufferData :: BufferPtr -> IO (Ptr ())
-getBufferData = {#get TF_Buffer->data #}
+getBufferData = {# get TF_Buffer->data #}
 
 getBufferLength :: BufferPtr -> IO CULong
-getBufferLength ={#get TF_Buffer->length #}
+getBufferLength = {# get TF_Buffer->length #}
 
 -- Tensor.
-{#pointer *TF_Tensor as Tensor newtype #}
+{# pointer *TF_Tensor as Tensor newtype #}
 
 instance Storable Tensor where
     sizeOf (Tensor t) = sizeOf t

--- a/tensorflow/src/TensorFlow/Types.hs
+++ b/tensorflow/src/TensorFlow/Types.hs
@@ -64,6 +64,7 @@ module TensorFlow.Types
     , AllTensorTypes
     ) where
 
+import Data.Bits (shiftL, (.|.))
 import Data.ProtoLens.Message(defMessage)
 import Data.Functor.Identity (Identity(..))
 import Data.Complex (Complex)
@@ -78,7 +79,6 @@ import GHC.Exts (Constraint, IsList(..))
 import Lens.Family2 (Lens', view, (&), (.~), (^..), under)
 import Lens.Family2.Unchecked (adapter)
 import Text.Printf (printf)
-import qualified Data.Attoparsec.ByteString as Atto
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 import Data.ByteString.Builder (Builder)
@@ -86,6 +86,7 @@ import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Lazy as L
 import qualified Data.Vector as V
 import qualified Data.Vector.Storable as S
+import Data.Vector.Split (chunksOf)
 import Proto.Tensorflow.Core.Framework.AttrValue
     ( AttrValue
     , AttrValue'ListValue
@@ -126,7 +127,7 @@ import Proto.Tensorflow.Core.Framework.TensorShape_Fields
     )
 import Proto.Tensorflow.Core.Framework.Types (DataType(..))
 
-import TensorFlow.Internal.VarInt (getVarInt, putVarInt)
+import qualified TensorFlow.Internal.Raw as Raw
 import qualified TensorFlow.Internal.FFI as FFI
 
 type ResourceHandle = ResourceHandleProto
@@ -317,50 +318,60 @@ instance {-# OVERLAPPING #-} TensorDataType V.Vector (Complex Double) where
     encodeTensorData = error "TODO (Complex Double)"
 
 instance {-# OVERLAPPING #-} TensorDataType V.Vector ByteString where
-    -- Encoded data layout (described in third_party/tensorflow/c/c_api.h):
-    --   table offsets for each element :: [Word64]
-    --   at each element offset:
-    --     string length :: VarInt64
-    --     string data   :: [Word8]
+    -- Strings can be encoded in various ways, see [0] for an overview.
+    --
+    -- The data starts with an array of TF_TString structs (24 bytes each), one
+    -- for each element in the tensor. In some cases, the actual string
+    -- contents are inlined in the TF_TString, in some cases they are in the
+    -- heap, in some cases they are appended to the end of the data.
+    --
+    -- When decoding, we delegate most of those details to the TString C API.
+    -- However, when encoding, the TString C API is prone to memory leaks given
+    -- the current design of tensorflow-haskell, so, instead we manually encode
+    -- all the strings in the "offset" format, where none of the string data is
+    -- stored in separate heap objects and so no destructor hook is necessary.
+    --
+    -- [0] https://github.com/tensorflow/community/blob/master/rfcs/20190411-string-unification.md
     decodeTensorData tensorData =
-        either (\err -> error $ "Malformed TF_STRING tensor; " ++ err) id $
-            if expected /= count
-                then Left $ "decodeTensorData for ByteString count mismatch " ++
-                            show (expected, count)
-                else V.mapM decodeString (S.convert offsets)
+        if S.length bytes < minBytes
+            then error $ "Malformed TF_STRING tensor; decodeTensorData for ByteString with too few bytes, got " ++
+                         show (S.length bytes) ++ ", need at least " ++ show minBytes
+            else V.fromList $ map FFI.unsafeTStringToByteString (take numElements (chunksOf 24 bytes))
       where
-        expected = S.length offsets
-        count = fromIntegral $ product $ FFI.tensorDataDimensions
-                    $ unTensorData tensorData
         bytes = FFI.tensorDataBytes $ unTensorData tensorData
-        offsets = S.take count $ S.unsafeCast bytes :: S.Vector Word64
-        dataBytes = B.pack $ S.toList $ S.drop (count * 8) bytes
-        decodeString :: Word64 -> Either String ByteString
-        decodeString offset =
-            let stringDataStart = B.drop (fromIntegral offset) dataBytes
-            in Atto.eitherResult $ Atto.parse stringParser stringDataStart
-        stringParser :: Atto.Parser ByteString
-        stringParser = getVarInt >>= Atto.take . fromIntegral
+        numElements = fromIntegral $ product $ FFI.tensorDataDimensions $ unTensorData tensorData
+        minBytes = Raw.sizeOfTString * numElements
     encodeTensorData (Shape xs) vec =
         TensorData $ FFI.TensorData xs dt byteVector
       where
         dt = tensorType (undefined :: ByteString)
+        tableSize = fromIntegral $ Raw.sizeOfTString * (V.length vec)
         -- Add a string to an offset table and data blob.
-        addString :: (Builder, Builder, Word64)
+        addString :: (Builder, Builder, Word32, Word32)
                   -> ByteString
-                  -> (Builder, Builder, Word64)
-        addString (table, strings, offset) str =
-            ( table <> Builder.word64LE offset
-            , strings <> lengthBytes <> Builder.byteString str
-            , offset + lengthBytesLen + strLen
+                  -> (Builder, Builder, Word32, Word32)
+        addString (table, strings, tableOffset, stringsOffset) str =
+            ( table <> Builder.word32LE sizeField
+                    <> Builder.word32LE offsetField
+                    <> Builder.word32LE capacityField
+                    <> Builder.word32LE 0
+                    <> Builder.word32LE 0
+                    <> Builder.word32LE 0
+            , strings <> Builder.byteString str
+            , tableOffset + fromIntegral Raw.sizeOfTString
+            , stringsOffset + strLen
             )
           where
-            strLen = fromIntegral $ B.length str
-            lengthBytes = putVarInt $ fromIntegral $ B.length str
-            lengthBytesLen =
-                fromIntegral $ L.length $ Builder.toLazyByteString lengthBytes
+            strLen :: Word32 = fromIntegral $ B.length str
+            -- TF_TString.size includes a union tag in the first two bits.
+            sizeField :: Word32 = (shiftL strLen 2) .|. Raw.tstringOffsetTypeTag
+            -- offset is relative to the start of the TF_TString instance, so
+            -- we add the remaining distance to the end of the table to the
+            -- offset from the start of the string data.
+            offsetField :: Word32 = tableSize - tableOffset + stringsOffset
+            capacityField :: Word32 = strLen
         -- Encode all strings.
-        (table', strings', _) = V.foldl' addString (mempty, mempty, 0) vec
+        (table', strings', _, _) = V.foldl' addString (mempty, mempty, 0, 0) vec
         -- Concat offset table with data.
         bytes = table' <> strings'
         -- Convert to Vector Word8.

--- a/tensorflow/tensorflow.cabal
+++ b/tensorflow/tensorflow.cabal
@@ -56,6 +56,7 @@ library
                 , temporary
                 , transformers
                 , vector
+                , vector-split
   extra-libraries:     tensorflow
   default-language:    Haskell2010
   include-dirs: .

--- a/tensorflow/tensorflow.cabal
+++ b/tensorflow/tensorflow.cabal
@@ -18,7 +18,7 @@ maintainer:          tensorflow-haskell@googlegroups.com
 copyright:           Google Inc.
 category:            Machine Learning
 build-type:          Simple
-cabal-version:       >=1.22
+cabal-version:       2.0
 extra-source-files: third_party/tensorflow/c/c_api.h
 
 library
@@ -35,7 +35,8 @@ library
                   , TensorFlow.Tensor
                   , TensorFlow.Types
   other-modules:    TensorFlow.Internal.Raw
-  build-tools:      c2hs
+  autogen-modules:  TensorFlow.Internal.Raw
+  build-tool-depends: c2hs:c2hs
   build-depends:  proto-lens == 0.7.*
                 , tensorflow-proto == 0.3.*
                 , base >= 4.7 && < 5


### PR DESCRIPTION
- [x] Update submodule to 2.10.1
- [x] Update Dockerfiles in `docker/` and `ci_build/` to `tensorflow/tensorflow:2.10.1`
  - [x] Verify that `stack --docker test` succeeds
- [x] Update Nix integration to nixpkgs that contains `libtensorflow` 2.10.1
  - [x] Verify that `stack --nix test` succeeds
- [x] Update protobuf file list
- [x] [Use new byte layout for string tensors
](https://github.com/tensorflow/tensorflow/releases/tag/v2.4.0) (breaking change; fixes `QueueTest` in `tensorflow-ops`)