### PR TITLE
Fix build for GHC 9.2

### DIFF
--- a/tensorflow/src/TensorFlow/Internal/VarInt.hs
+++ b/tensorflow/src/TensorFlow/Internal/VarInt.hs
@@ -27,7 +27,7 @@ module TensorFlow.Internal.VarInt
 
 import Data.Attoparsec.ByteString as Parse
 import Data.Bits
-import Data.ByteString.Lazy.Builder as Builder
+import Data.ByteString.Builder as Builder
 import Data.Word (Word64)
 
 -- | Decode an unsigned varint.

--- a/tensorflow/tensorflow.cabal
+++ b/tensorflow/tensorflow.cabal
@@ -42,7 +42,7 @@ library
                 , base >= 4.7 && < 5
                 , async
                 , attoparsec
-                , bytestring
+                , bytestring >= 0.10.2
                 , containers
                 , data-default
                 , exceptions


### PR DESCRIPTION
`Data.ByteString.Lazy.Builder` has been removed.