### PR TITLE
Fix min version guard for Cabal

### DIFF
--- a/tensorflow-core-ops/Setup.hs
+++ b/tensorflow-core-ops/Setup.hs
@@ -28,7 +28,7 @@ import Distribution.Simple
     , simpleUserHooks
     , UserHooks(..)
     )
-#if MIN_VERSION_Cabal(3,1,0)
+#if MIN_VERSION_Cabal(3,6,0)
 import Distribution.Utils.Path (unsafeMakeSymbolicPath)
 #endif
 import Data.List (intercalate)
@@ -84,7 +84,7 @@ fudgePackageDesc lbi p = p
     }
   where
     fudgeBuildInfo bi =
-#if MIN_VERSION_Cabal(3,1,0)
+#if MIN_VERSION_Cabal(3,6,0)
         bi { hsSourceDirs = unsafeMakeSymbolicPath (autogenModulesDir lbi) : hsSourceDirs bi }
 #else    
         bi { hsSourceDirs = autogenModulesDir lbi : hsSourceDirs bi }


### PR DESCRIPTION
I was still getting build failures of `tensorflow-core-ops` even after #289:

```
/home/johannes/ag/anomaly-detection/ghc-90/haskell/tensorflow-core-ops/dist-newstyle/build/x86_64-linux/ghc-9.0.2/tensorflow-core-ops-0.3.0.0/setup/setup.hs:32:1: error:
    Could not find module ‘Distribution.Utils.Path’
    Perhaps you meant
      Distribution.Utils.IOData (from Cabal-3.4.1.0)
      Distribution.Utils.MD5 (from Cabal-3.4.1.0)
      Distribution.Utils.Base62
    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
   |
32 | import Distribution.Utils.Path (unsafeMakeSymbolicPath)
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Checking hackage, the earliest exposure of the `Distribution.Utils.Path` module is in version 3.6 (https://hackage.haskell.org/package/Cabal-3.6.0.0) instead of 3.1 as guarded against.