### PR TITLE
Fix lens errors

### DIFF
--- a/tensorflow-ops/src/TensorFlow/Gradient.hs
+++ b/tensorflow-ops/src/TensorFlow/Gradient.hs
@@ -168,7 +168,7 @@ gradients y xs = build $ do
         (\f x -> fromMaybe (error $ "no NodeDef found for " ++ show x) (f x))
         . flip Map.lookup
     let (gr, nodeMap) = createGraph yName nodeDefLookup
-        xnodes = mapMaybe (\x -> nodeMap ^. (at . outputNodeName . renderedOutput $ x)) xs
+        xnodes = mapMaybe (\x -> nodeMap ^. (at $ outputNodeName $ renderedOutput x)) xs
         -- make a set of the nodes reachable from the xnodes
         -- The xnodes are not part of this set (unless reachable from another xnode)
         reachableSet = computeReachableSet xnodes gr
@@ -199,7 +199,8 @@ computeReachableSet vs g =
   IntSet.fromList $ concatMap (drop 1 . FGL.preorder) (FGL.dff vs g)
 
 outputIxAt :: OutputIx -> Lens' (IntMap.IntMap v) (Maybe v)
-outputIxAt = intAt . unOutputIx
+-- NOTE: point-free notation leads to unification problems here
+outputIxAt x = intAt (unOutputIx x)
 
 -- | Incomplete gradients of a node's outputs.
 --


### PR DESCRIPTION
I was getting these cryptic errors when building `tensorflow-ops` with GHC 9.0.2, but I can't really pinpoint what packages/versions are responsible:

```
[4 of 8] Compiling TensorFlow.Gradient ( src/TensorFlow/Gradient.hs, /home/johannes/ag/anomaly-detection/ghc-90/haskell/tensorflow-ops/dist-newstyle/build/x86_64-linux/ghc-9.0.2/tensorflow-ops-0.3.0.0/build/TensorFlow/Gradient.o, /home/johannes/ag/anomaly-detection/ghc-90/haskell/tensorflow-ops/dist-newstyle/build/x86_64-linux/ghc-9.0.2/tensorflow-ops-0.3.0.0/build/TensorFlow/Gradient.dyn_o )

src/TensorFlow/Gradient.hs:171:46: error:
    • Couldn't match type: Lens' (Map NodeName v1) (Maybe v1)
                     with: lens-family-core-2.1.2:Lens.Family.FoldLike
                             (Maybe FGL.Node) (Map NodeName FGL.Node) t0 (Maybe FGL.Node) b0
      Expected: NodeName
                -> lens-family-core-2.1.2:Lens.Family.FoldLike
                     (Maybe FGL.Node) (Map NodeName FGL.Node) t0 (Maybe FGL.Node) b0
        Actual: NodeName -> Lens' (Map NodeName v1) (Maybe v1)
    • In the first argument of ‘(.)’, namely ‘at’
      In the first argument of ‘($)’, namely
        ‘at . outputNodeName . renderedOutput’
      In the second argument of ‘(^.)’, namely
        ‘(at . outputNodeName . renderedOutput $ x)’
    |
171 |         xnodes = mapMaybe (\x -> nodeMap ^. (at . outputNodeName . renderedOutput $ x)) xs
    |                                              ^^

src/TensorFlow/Gradient.hs:202:14: error:
    • Couldn't match type ‘c0’
                     with ‘Lens' (IntMap.IntMap v0) (Maybe v0)’
      Expected: Int -> c0
        Actual: Int -> Lens' (IntMap.IntMap v0) (Maybe v0)
      Cannot instantiate unification variable ‘c0’
      with a type involving polytypes:
        Lens' (IntMap.IntMap v0) (Maybe v0)
    • In the first argument of ‘(.)’, namely ‘intAt’
      In the expression: intAt . unOutputIx
      In an equation for ‘outputIxAt’: outputIxAt = intAt . unOutputIx
    |
202 | outputIxAt = intAt . unOutputIx
    |              ^^^^^

src/TensorFlow/Gradient.hs:202:14: error:
    • Couldn't match type ‘c0’ with ‘Lens' (IntMap.IntMap v) (Maybe v)’
      Expected: OutputIx -> Lens' (IntMap.IntMap v) (Maybe v)
        Actual: OutputIx -> c0
      Cannot instantiate unification variable ‘c0’
      with a type involving polytypes: Lens' (IntMap.IntMap v) (Maybe v)
    • In the expression: intAt . unOutputIx
      In an equation for ‘outputIxAt’: outputIxAt = intAt . unOutputIx
    • Relevant bindings include
        outputIxAt :: OutputIx -> Lens' (IntMap.IntMap v) (Maybe v)
          (bound at src/TensorFlow/Gradient.hs:202:1)
    |
202 | outputIxAt = intAt . unOutputIx
    |              ^^^^^^^^^^^^^^^^^^
```

Replacing point-free notation in two spots resolved the errors for me, so I've attached the fix. But I don't know whether that's preferable or if we should maybe try and find the root reason for this.